### PR TITLE
Multiactions/linucb

### DIFF
--- a/examples/movielens_bandit.py
+++ b/examples/movielens_bandit.py
@@ -14,6 +14,7 @@ from striatum.bandit import linucb
 from striatum.bandit import linthompsamp
 from striatum.bandit import exp4p
 from striatum.bandit import exp3
+from striatum.bandit.bandit import Action
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.linear_model import LogisticRegression
 from sklearn.multiclass import OneVsRestClassifier
@@ -22,13 +23,18 @@ from sklearn.multiclass import OneVsRestClassifier
 def get_data():
     streaming_batch = pd.read_csv('streaming_batch.csv', sep='\t', names=['user_id'], engine='c')
     user_feature = pd.read_csv('user_feature.csv', sep='\t', header=0, index_col=0, engine='c')
-    actions = list(pd.read_csv('actions.csv', sep='\t', header=0, engine='c')['movie_id'])
+    actions_id = list(pd.read_csv('actions.csv', sep='\t', header=0, engine='c')['movie_id'])
     reward_list = pd.read_csv('reward_list.csv', sep='\t', header=0, engine='c')
     action_context = pd.read_csv('action_context.csv', sep='\t', header=0, engine='c')
+
+    actions = []
+    for key in actions_id:
+        action = Action(key, key, key)
+        actions.append(action)
     return streaming_batch, user_feature, actions, reward_list, action_context
 
 
-def expert_training(action_context):
+def train_expert(action_context):
     logreg = OneVsRestClassifier(LogisticRegression())
     mnb = OneVsRestClassifier(MultinomialNB(), )
     logreg.fit(action_context.iloc[:, 2:], action_context.iloc[:, 1])
@@ -36,20 +42,31 @@ def expert_training(action_context):
     return [logreg, mnb]
 
 
-def policy_generation(bandit, action_context, actions):
+def get_advice(context, actions_id, experts):
+    advice = {}
+    for time in context.keys():
+        advice[time] = {}
+        for i in range(len(experts)):
+            prob = experts[i].predict_proba(context[time])[0]
+            advice[time][i] = {}
+            for j in range(len(prob)):
+                advice[time][i][actions_id[j]] = prob[j]
+    return advice
+
+
+def policy_generation(bandit, actions):
     historystorage = history.MemoryHistoryStorage()
     modelstorage = model.MemoryModelStorage()
 
     if bandit == 'Exp4P':
-        models = expert_training(action_context)
-        policy = exp4p.Exp4P(actions, historystorage, modelstorage, models, delta=0.5, pmin=None)
+        policy = exp4p.Exp4P(actions, historystorage, modelstorage, delta=0.5, pmin=None)
 
     elif bandit == 'LinUCB':
-        policy = linucb.LinUCB(actions, historystorage, modelstorage, 0.5, 20)
+        policy = linucb.LinUCB(actions, historystorage, modelstorage, 0.3, 20)
 
     elif bandit == 'LinThompSamp':
         policy = linthompsamp.LinThompSamp(actions, historystorage, modelstorage,
-                                           d=20, delta=0.9, r=0.01, epsilon=0.5)
+                                           d=20, delta=0.61, r=0.01, epsilon=0.71)
 
     elif bandit == 'UCB1':
         policy = ucb1.UCB1(actions, historystorage, modelstorage)
@@ -63,50 +80,59 @@ def policy_generation(bandit, action_context, actions):
     return policy
 
 
-def policy_evaluation(policy, bandit, streaming_batch, user_feature, reward_list, actions):
+def policy_evaluation(policy, bandit, streaming_batch, user_feature, reward_list, actions, action_context=None):
     times = len(streaming_batch)
     seq_error = np.zeros(shape=(times, 1))
+    actions_id = [actions[i].action_id for i in range(len(actions))]
     if bandit in ['LinUCB', 'LinThompSamp', 'UCB1', 'Exp3']:
-
         for t in range(times):
-            feature = user_feature[user_feature.index == streaming_batch.iloc[t, 0]]
-            full_context = pd.DataFrame(np.repeat(np.array(feature), 50, axis=0)).as_matrix()
-            history_id, action = policy.get_action(full_context)
+            feature = np.array(user_feature[user_feature.index == streaming_batch.iloc[t, 0]])[0]
+            full_context = {}
+            for action_id in actions_id:
+                full_context[action_id] = feature
+            history_id, action = policy.get_action(full_context, 1)
             watched_list = reward_list[reward_list['user_id'] == streaming_batch.iloc[t, 0]]
 
-            if action not in list(watched_list['movie_id']):
-                policy.reward(history_id, 0)
+            if action[0]['action'].action_id not in list(watched_list['movie_id']):
+                policy.reward(history_id, {action[0]['action'].action_id: 0.0})
                 if t == 0:
                     seq_error[t] = 1.0
                 else:
                     seq_error[t] = seq_error[t - 1] + 1.0
 
             else:
-                policy.reward(history_id, 1)
+                policy.reward(history_id, {action[0]['action'].action_id: 1.0})
                 if t > 0:
                     seq_error[t] = seq_error[t - 1]
 
     elif bandit == 'Exp4P':
         for t in range(times):
             feature = user_feature[user_feature.index == streaming_batch.iloc[t, 0]]
-            history_id, action = policy.get_action(list(feature.iloc[0]))
+            experts = train_expert(action_context)
+            advice = {}
+            for i in range(len(experts)):
+                prob = experts[i].predict_proba(feature)[0]
+                advice[i] = {}
+                for j in range(len(prob)):
+                    advice[i][actions_id[j]] = prob[j]
+            history_id, action = policy.get_action(advice)
             watched_list = reward_list[reward_list['user_id'] == streaming_batch.iloc[t, 0]]
 
-            if action not in list(watched_list['movie_id']):
-                policy.reward(history_id, 0)
+            if action[0]['action'].action_id not in list(watched_list['movie_id']):
+                policy.reward(history_id, {action[0]['action'].action_id: 0.0})
                 if t == 0:
                     seq_error[t] = 1.0
                 else:
                     seq_error[t] = seq_error[t - 1] + 1.0
 
             else:
-                policy.reward(history_id, 1)
+                policy.reward(history_id, {action[0]['action'].action_id: 1.0})
                 if t > 0:
                     seq_error[t] = seq_error[t - 1]
 
     elif bandit == 'random':
         for t in range(times):
-            action = actions[np.random.randint(0, len(actions)-1)]
+            action = actions_id[np.random.randint(0, len(actions)-1)]
             watched_list = reward_list[reward_list['user_id'] == streaming_batch.iloc[t, 0]]
 
             if action not in list(watched_list['movie_id']):
@@ -138,8 +164,9 @@ def main():
     col = ['b', 'g', 'r', 'c', 'm', 'y', 'k', 'w']
     i = 0
     for bandit in experiment_bandit:
-        policy = policy_generation(bandit, action_context, actions)
-        seq_error = policy_evaluation(policy, bandit, streaming_batch_small, user_feature, reward_list, actions)
+        policy = policy_generation(bandit, actions)
+        seq_error = policy_evaluation(policy, bandit, streaming_batch_small, user_feature, reward_list,
+                                      actions, action_context)
         regret[bandit] = regret_calculation(seq_error)
         plt.plot(range(len(streaming_batch_small)), regret[bandit], c=col[i], ls='-', label=bandit)
         plt.xlabel('time')

--- a/examples/movielens_bandit.py
+++ b/examples/movielens_bandit.py
@@ -29,7 +29,7 @@ def get_data():
 
     actions = []
     for key in actions_id:
-        action = Action(key, key, key)
+        action = Action(key)
         actions.append(action)
     return streaming_batch, user_feature, actions, reward_list, action_context
 

--- a/simulation/simulation_exp3.py
+++ b/simulation/simulation_exp3.py
@@ -10,11 +10,11 @@ from striatum.bandit.bandit import Action
 def main():
     times = 1000
     d = 5
-    a1 = Action(1, 'a1', 'content 1')
-    a2 = Action(2, 'a2', 'content 2')
-    a3 = Action(3, 'a3', 'content 3')
-    a4 = Action(4, 'a4', 'content 4')
-    a5 = Action(5, 'a5', 'content 5')
+    a1 = Action(1)
+    a2 = Action(2)
+    a3 = Action(3)
+    a4 = Action(4)
+    a5 = Action(5)
     actions = [a1, a2, a3, a4, a5]
 
     # Parameter tunning

--- a/simulation/simulation_exp3.py
+++ b/simulation/simulation_exp3.py
@@ -4,12 +4,18 @@ from striatum.bandit import exp3
 from striatum import simulation
 import numpy as np
 import matplotlib.pyplot as plt
+from striatum.bandit.bandit import Action
 
 
 def main():
     times = 1000
     d = 5
-    actions = [1, 2, 3, 4, 5]
+    a1 = Action(1, 'a1', 'content 1')
+    a2 = Action(2, 'a2', 'content 2')
+    a3 = Action(3, 'a3', 'content 3')
+    a4 = Action(4, 'a4', 'content 4')
+    a5 = Action(5, 'a5', 'content 5')
+    actions = [a1, a2, a3, a4, a5]
 
     # Parameter tunning
     tunning_region = np.arange(0.001, 1, 0.03)

--- a/simulation/simulation_exp4p.py
+++ b/simulation/simulation_exp4p.py
@@ -17,6 +17,7 @@ def train_expert(history_context, history_action):
     mnb.fit(history_context, history_action)
     return [logreg, mnb]
 
+
 def get_advice(context, actions_id, experts):
     advice = {}
     for time in context.keys():

--- a/simulation/simulation_exp4p.py
+++ b/simulation/simulation_exp4p.py
@@ -33,11 +33,11 @@ def get_advice(context, actions_id, experts):
 def main():
     times = 1000
     d = 5
-    a1 = Action(1, 'a1', 'content 1')
-    a2 = Action(2, 'a2', 'content 2')
-    a3 = Action(3, 'a3', 'content 3')
-    a4 = Action(4, 'a4', 'content 4')
-    a5 = Action(5, 'a5', 'content 5')
+    a1 = Action(1)
+    a2 = Action(2)
+    a3 = Action(3)
+    a4 = Action(4)
+    a5 = Action(5)
     actions = [a1, a2, a3, a4, a5]
     actions_id = [1, 2, 3, 4, 5]
     history_context, history_action = simulation.data_simulation(3000, d, actions, "Exp4P")

--- a/simulation/simulation_linthompsamp.py
+++ b/simulation/simulation_linthompsamp.py
@@ -12,11 +12,11 @@ def main():
 
     times = 1000
     d = 5
-    a1 = Action(1, 'a1', 'content 1')
-    a2 = Action(2, 'a2', 'content 2')
-    a3 = Action(3, 'a3', 'content 3')
-    a4 = Action(4, 'a4', 'content 4')
-    a5 = Action(5, 'a5', 'content 5')
+    a1 = Action(1)
+    a2 = Action(2)
+    a3 = Action(3)
+    a4 = Action(4)
+    a5 = Action(5)
     actions = [a1, a2, a3, a4, a5]
 
     # Parameter tunning

--- a/simulation/simulation_linthompsamp.py
+++ b/simulation/simulation_linthompsamp.py
@@ -5,12 +5,18 @@ from striatum import simulation
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.lines as mlines
+from striatum.bandit.bandit import Action
 
 
 def main():
     times = 1000
     d = 5
-    actions = [1, 2, 3, 4, 5]
+    a1 = Action(1, 'a1', 'content 1')
+    a2 = Action(2, 'a2', 'content 2')
+    a3 = Action(3, 'a3', 'content 3')
+    a4 = Action(4, 'a4', 'content 4')
+    a5 = Action(5, 'a5', 'content 5')
+    actions = [a1, a2, a3, a4, a5]
 
     # Parameter tunning
     tunning_region = np.arange(0.01, 0.99, 0.1)

--- a/simulation/simulation_linthompsamp.py
+++ b/simulation/simulation_linthompsamp.py
@@ -9,6 +9,7 @@ from striatum.bandit.bandit import Action
 
 
 def main():
+
     times = 1000
     d = 5
     a1 = Action(1, 'a1', 'content 1')
@@ -85,8 +86,8 @@ def main():
     policy = linthompsamp.LinThompSamp(actions, historystorage, modelstorage,
                                        d=d, delta=delta_opt, r=r_opt, epsilon=epsilon_opt)
     regret = simulation.regret_calculation(simulation.policy_evaluation(policy, context2, desired_action2))
-    simulation.regret_plot(times, regret,
-                   label='delta = ' + str(delta_opt) + ', r = ' + str(r_opt) + ', epsilon = ' + str(epsilon_opt))
+    simulation.regret_plot(times, regret, label='delta = ' + str(delta_opt) +
+                                                ', r = ' + str(r_opt) + ', epsilon = ' + str(epsilon_opt))
 
 
 if __name__ == '__main__':

--- a/simulation/simulation_linucb.py
+++ b/simulation/simulation_linucb.py
@@ -9,11 +9,11 @@ from striatum.bandit.bandit import Action
 def main():
     times = 1000
     d = 5
-    a1 = Action(1, 'a1', 'content 1')
-    a2 = Action(2, 'a2', 'content 2')
-    a3 = Action(3, 'a3', 'content 3')
-    a4 = Action(4, 'a4', 'content 4')
-    a5 = Action(5, 'a5', 'content 5')
+    a1 = Action(1)
+    a2 = Action(2)
+    a3 = Action(3)
+    a4 = Action(4)
+    a5 = Action(5)
     actions = [a1, a2, a3, a4, a5]
 
     # Parameter tunning

--- a/simulation/simulation_linucb.py
+++ b/simulation/simulation_linucb.py
@@ -5,6 +5,7 @@ from striatum import simulation
 import numpy as np
 from striatum.bandit.bandit import Action
 
+
 def main():
     times = 1000
     d = 5

--- a/simulation/simulation_linucb.py
+++ b/simulation/simulation_linucb.py
@@ -3,12 +3,17 @@ from striatum.storage import model
 from striatum.bandit import linucb
 from striatum import simulation
 import numpy as np
-
+from striatum.bandit.bandit import Action
 
 def main():
     times = 1000
     d = 5
-    actions = [1, 2, 3, 4, 5]
+    a1 = Action(1, 'a1', 'content 1')
+    a2 = Action(2, 'a2', 'content 2')
+    a3 = Action(3, 'a3', 'content 3')
+    a4 = Action(4, 'a4', 'content 4')
+    a5 = Action(5, 'a5', 'content 5')
+    actions = [a1, a2, a3, a4, a5]
 
     # Parameter tunning
     tunning_region = np.arange(0, 3, 0.05)

--- a/simulation/simulation_ucb1.py
+++ b/simulation/simulation_ucb1.py
@@ -3,15 +3,20 @@ from striatum.storage import model
 from striatum.bandit import ucb1
 from striatum import simulation
 import matplotlib.pyplot as plt
+from striatum.bandit.bandit import Action
 
 
 def main():
-    times = 1000
     d = 5
-    actions = [1, 2, 3, 4, 5]
+    a1 = Action(1, 'a1', 'content 1')
+    a2 = Action(2, 'a2', 'content 2')
+    a3 = Action(3, 'a3', 'content 3')
+    a4 = Action(4, 'a4', 'content 4')
+    a5 = Action(5, 'a5', 'content 5')
+    actions = [a1, a2, a3, a4, a5]
 
     # Regret Analysis
-    times = 20000
+    times = 40000
     context, desired_action = simulation.data_simulation(times, d, actions)
     historystorage = history.MemoryHistoryStorage()
     modelstorage = model.MemoryModelStorage()

--- a/simulation/simulation_ucb1.py
+++ b/simulation/simulation_ucb1.py
@@ -8,11 +8,11 @@ from striatum.bandit.bandit import Action
 
 def main():
     d = 5
-    a1 = Action(1, 'a1', 'content 1')
-    a2 = Action(2, 'a2', 'content 2')
-    a3 = Action(3, 'a3', 'content 3')
-    a4 = Action(4, 'a4', 'content 4')
-    a5 = Action(5, 'a5', 'content 5')
+    a1 = Action(1)
+    a2 = Action(2)
+    a3 = Action(3)
+    a4 = Action(4)
+    a5 = Action(5)
     actions = [a1, a2, a3, a4, a5]
 
     # Regret Analysis

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -11,17 +11,9 @@ class Action(object):
     ----------
     action_id: int
         The index of this action.
-
-    title: string
-        The title of this action.
-
-    content: object
-        The content of this action.
     """
-    def __init__(self, action_id, title, content):
+    def __init__(self, action_id):
         self.action_id = action_id
-        self.title = title
-        self.content = content
 
 
 class BaseBandit(object):

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -92,7 +92,7 @@ class BaseBandit(object):
                 The history id of the action.
 
             action_recommend : list of dictionaries
-                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
+                In each dictionary, it will contains {Action object, estimated_reward, uncertainty}
         """
         pass
 

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -40,16 +40,16 @@ class BaseBandit(object):
 
     Attributes
     ----------
-    historystorage : historystorage object
+    \_historystorage : historystorage object
         The historystorage object to store history context, actions and rewards.
 
-    modelstorage : modelstorage object
+    \_modelstorage : modelstorage object
         The modelstorage object to store model parameters.
 
-    actions : list of Action objects
+    \_actions : list of Action objects
         List of actions to be chosen from.
 
-    actions_id: list of integers
+    \_action_ids: list of integers
         List of all action_id's.
     """
 
@@ -57,7 +57,6 @@ class BaseBandit(object):
         self._historystorage = historystorage
         self._modelstorage = modelstorage
         self._actions = actions
-        self._actions_id = [actions[i].action_id for i in range(len(actions))]
 
     @property
     def historystorage(self):
@@ -73,6 +72,10 @@ class BaseBandit(object):
     def actions(self):
         """List of actions"""
         return self._actions
+
+    @property
+    def action_ids(self):
+        return [self._actions[i].action_id for i in range(len(self._actions))]
 
     @abstractmethod
     def get_action(self, context, n_actions=1):

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -116,7 +116,7 @@ class BaseBandit(object):
 
             Parameters
             ----------
-            actions : {array-like, None}
-                Actions (arms) for recommendation
+            actions : list
+                A list of Action objects for recommendation
         """
         pass

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -105,3 +105,13 @@ class BaseBandit(object):
         """
         pass
 
+    @abstractmethod
+    def add_action(self, actions):
+        """ Add new actions (if needed).
+
+        Parameters
+        ----------
+        actions : {array-like, None}
+            Actions (arms) for recommendation
+        """
+    pass

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -4,12 +4,20 @@ Bandit interfaces
 from abc import abstractmethod
 
 
-# TODO: think about how to use this
 class Action(object):
-    """The action object"""
-    @abstractmethod
-    def __init__(self):
-        pass
+    """The action object
+
+    Parameters
+    ----------
+        action_id: int
+            The idx of this action.
+        title:
+        content:
+    """
+    def __init__(self, action_id, title, content):
+        self.action_id = action_id
+        self.title = title
+        self.content = content
 
 
 class BaseBandit(object):
@@ -36,11 +44,15 @@ class BaseBandit(object):
 
     actions : list of Action objects
         List of actions to be chosen from.
+
+    actions_id: list of integers
+        List of all action_id's.
     """
     def __init__(self, historystorage, modelstorage, actions):
         self._historystorage = historystorage
         self._modelstorage = modelstorage
         self._actions = actions
+        self._actions_id = [actions[i].action_id for i in range(len(actions))]
 
     @property
     def historystorage(self):
@@ -58,13 +70,16 @@ class BaseBandit(object):
         return self._actions
 
     @abstractmethod
-    def get_action(self, context):
+    def get_action(self, context, n_action=1):
         """Return the action to perform
 
         Parameters
         ----------
         context : {array-like, None}
-            The context of current state, None if no context avaliable.
+            The context of current state, None if no context available.
+
+        n_action: int
+                Number of actions wanted to recommend users.
 
         Returns
         -------
@@ -78,15 +93,15 @@ class BaseBandit(object):
 
     @abstractmethod
     def reward(self, history_id, reward):
-        """Reward the preivous action with reward.
+        """Reward the previous action with reward.
 
         Parameters
         ----------
         history_id : int
             The history id of the action to reward.
 
-        reward : float
-            A float representing the feedback given to the action, the higher
-            the better.
+        reward : dictionary
+            The dictionary {action_id, reward}, where reward is a float.
         """
         pass
+

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -7,12 +7,16 @@ from abc import abstractmethod
 class Action(object):
     """The action object
 
-    Parameters
-    ----------
+        Parameters
+        ----------
         action_id: int
-            The idx of this action.
-        title:
-        content:
+            The index of this action.
+
+        title: string
+            The title of this action.
+
+        content: object
+            The content of this action.
     """
     def __init__(self, action_id, title, content):
         self.action_id = action_id
@@ -23,31 +27,32 @@ class Action(object):
 class BaseBandit(object):
     """Bandit algorithm
 
-    Parameters
-    ----------
-    historystorage : historystorage object
-        The historystorage object to store history context, actions and rewards.
+        Parameters
+        ----------
+        historystorage : historystorage object
+            The historystorage object to store history context, actions and rewards.
 
-    modelstorage : modelstorage object
-        The modelstorage object to store model parameters.
+        modelstorage : modelstorage object
+            The modelstorage object to store model parameters.
 
-    actions : list of Action objects
-        List of actions to be chosen from.
+        actions : list of Action objects
+            List of actions to be chosen from.
 
-    Attributes
-    ----------
-    historystorage : historystorage object
-        The historystorage object to store history context, actions and rewards.
+        Attributes
+        ----------
+        historystorage : historystorage object
+            The historystorage object to store history context, actions and rewards.
 
-    modelstorage : modelstorage object
-        The modelstorage object to store model parameters.
+        modelstorage : modelstorage object
+            The modelstorage object to store model parameters.
 
-    actions : list of Action objects
-        List of actions to be chosen from.
+        actions : list of Action objects
+            List of actions to be chosen from.
 
-    actions_id: list of integers
-        List of all action_id's.
+        actions_id: list of integers
+            List of all action_id's.
     """
+
     def __init__(self, historystorage, modelstorage, actions):
         self._historystorage = historystorage
         self._modelstorage = modelstorage
@@ -73,21 +78,21 @@ class BaseBandit(object):
     def get_action(self, context, n_action=1):
         """Return the action to perform
 
-        Parameters
-        ----------
-        context : {array-like, None}
-            The context of current state, None if no context available.
+            Parameters
+            ----------
+            context : dictionary
+                Contexts {action_id: context} of different actions.
 
-        n_action: int
+            n_action: int
                 Number of actions wanted to recommend users.
 
-        Returns
-        -------
-        history_id : int
-            The history id of the action.
+            Returns
+            -------
+            history_id : int
+                The history id of the action.
 
-        action : list of dictionaries
-            In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
+            action_recommend : list of dictionaries
+                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
         """
         pass
 
@@ -95,13 +100,13 @@ class BaseBandit(object):
     def reward(self, history_id, reward):
         """Reward the previous action with reward.
 
-        Parameters
-        ----------
-        history_id : int
-            The history id of the action to reward.
+            Parameters
+            ----------
+            history_id : int
+                The history id of the action to reward.
 
-        reward : dictionary
-            The dictionary {action_id, reward}, where reward is a float.
+            reward : dictionary
+                The dictionary {action_id, reward}, where reward is a float.
         """
         pass
 
@@ -109,9 +114,9 @@ class BaseBandit(object):
     def add_action(self, actions):
         """ Add new actions (if needed).
 
-        Parameters
-        ----------
-        actions : {array-like, None}
-            Actions (arms) for recommendation
+            Parameters
+            ----------
+            actions : {array-like, None}
+                Actions (arms) for recommendation
         """
-    pass
+        pass

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -86,8 +86,8 @@ class BaseBandit(object):
         history_id : int
             The history id of the action.
 
-        action : Actions object
-            The action to perform.
+        action : list of dictionaries
+            In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
         """
         pass
 

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -7,16 +7,16 @@ from abc import abstractmethod
 class Action(object):
     """The action object
 
-        Parameters
-        ----------
-        action_id: int
-            The index of this action.
+    Parameters
+    ----------
+    action_id: int
+        The index of this action.
 
-        title: string
-            The title of this action.
+    title: string
+        The title of this action.
 
-        content: object
-            The content of this action.
+    content: object
+        The content of this action.
     """
     def __init__(self, action_id, title, content):
         self.action_id = action_id
@@ -27,30 +27,30 @@ class Action(object):
 class BaseBandit(object):
     """Bandit algorithm
 
-        Parameters
-        ----------
-        historystorage : historystorage object
-            The historystorage object to store history context, actions and rewards.
+    Parameters
+    ----------
+    historystorage : historystorage object
+        The historystorage object to store history context, actions and rewards.
 
-        modelstorage : modelstorage object
-            The modelstorage object to store model parameters.
+    modelstorage : modelstorage object
+        The modelstorage object to store model parameters.
 
-        actions : list of Action objects
-            List of actions to be chosen from.
+    actions : list of Action objects
+        List of actions to be chosen from.
 
-        Attributes
-        ----------
-        historystorage : historystorage object
-            The historystorage object to store history context, actions and rewards.
+    Attributes
+    ----------
+    historystorage : historystorage object
+        The historystorage object to store history context, actions and rewards.
 
-        modelstorage : modelstorage object
-            The modelstorage object to store model parameters.
+    modelstorage : modelstorage object
+        The modelstorage object to store model parameters.
 
-        actions : list of Action objects
-            List of actions to be chosen from.
+    actions : list of Action objects
+        List of actions to be chosen from.
 
-        actions_id: list of integers
-            List of all action_id's.
+    actions_id: list of integers
+        List of all action_id's.
     """
 
     def __init__(self, historystorage, modelstorage, actions):
@@ -75,38 +75,38 @@ class BaseBandit(object):
         return self._actions
 
     @abstractmethod
-    def get_action(self, context, n_action=1):
+    def get_action(self, context, n_actions=1):
         """Return the action to perform
 
-            Parameters
-            ----------
-            context : dictionary
-                Contexts {action_id: context} of different actions.
+        Parameters
+        ----------
+        context : dictionary
+            Contexts {action_id: context} of different actions.
 
-            n_action: int
-                Number of actions wanted to recommend users.
+        n_actions: int
+            Number of actions wanted to recommend users.
 
-            Returns
-            -------
-            history_id : int
-                The history id of the action.
+        Returns
+        -------
+        history_id : int
+            The history id of the action.
 
-            action_recommend : list of dictionaries
-                In each dictionary, it will contains {Action object, estimated_reward, uncertainty}
+        action_recommendation : list of dictionaries
+            In each dictionary, it will contains {Action object, estimated_reward, uncertainty}.
         """
         pass
 
     @abstractmethod
-    def reward(self, history_id, reward):
+    def reward(self, history_id, rewards):
         """Reward the previous action with reward.
 
-            Parameters
-            ----------
-            history_id : int
-                The history id of the action to reward.
+        Parameters
+        ----------
+        history_id : int
+            The history id of the action to reward.
 
-            reward : dictionary
-                The dictionary {action_id, reward}, where reward is a float.
+        rewards : dictionary
+            The dictionary {action_id, reward}, where reward is a float.
         """
         pass
 
@@ -114,9 +114,9 @@ class BaseBandit(object):
     def add_action(self, actions):
         """ Add new actions (if needed).
 
-            Parameters
-            ----------
-            actions : list
-                A list of Action objects for recommendation
+        Parameters
+        ----------
+        actions : iterable
+            A list of Action objects for recommendation
         """
         pass

--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -107,7 +107,7 @@ class Exp3(BaseBandit):
                 The history id of the action.
 
             action : list of dictionaries
-                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
+                In each dictionary, it will contains {Action object, estimated_reward, uncertainty}
         """
 
         if self.exp3_ is None:

--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -59,7 +59,7 @@ class Exp3(BaseBandit):
         # Initialize the model storage
         query_vector = {}
         w = {}
-        for action_id in self._actions_id:
+        for action_id in self.action_ids:
             query_vector[action_id] = 0     # probability distribution for action recommendation)
             w[action_id] = 1                # weight vector
         self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
@@ -73,15 +73,15 @@ class Exp3(BaseBandit):
             w_sum = np.sum(w.values())
 
             query_vector = {}
-            for action_id in self._actions_id:
-                query_vector[action_id] = (1 - self.gamma) * w[action_id] / w_sum + self.gamma / len(self._actions_id)
+            for action_id in self.action_ids:
+                query_vector[action_id] = (1 - self.gamma) * w[action_id] / w_sum + self.gamma / len(self.action_ids)
 
             self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
 
             estimated_reward = {}
             uncertainty = {}
             score = {}
-            for action_id in self._actions_id:
+            for action_id in self.action_ids:
                 estimated_reward[action_id] = query_vector[action_id]
                 uncertainty[action_id] = 0
                 score[action_id] = query_vector[action_id]
@@ -117,7 +117,7 @@ class Exp3(BaseBandit):
             estimated_reward, uncertainty, score = six.next(self.exp3_)
 
         action_recommendation = []
-        action_recommendation_ids = np.random.choice(self._actions_id, size=n_actions, p=score.values(), replace=False)
+        action_recommendation_ids = np.random.choice(self.action_ids, size=n_actions, p=score.values(), replace=False)
 
         for action_id in action_recommendation_ids:
             action_id = int(action_id)
@@ -150,7 +150,7 @@ class Exp3(BaseBandit):
             for i in actions_id:
                 rhat[i] = 0.0
             rhat[action_id] = reward_tmp / query_vector[action_id]
-            w[action_id] *= np.exp(self.gamma * rhat[action_id] / len(self._actions_id))
+            w[action_id] *= np.exp(self.gamma * rhat[action_id] / len(self.action_ids))
 
         self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
 
@@ -165,13 +165,12 @@ class Exp3(BaseBandit):
         actions : iterable
             A list of Action objects for recommendation
         """
-        actions_id = [actions[i].action_id for i in range(len(actions))]
+        action_ids = [actions[i].action_id for i in range(len(actions))]
         w = self._modelstorage.get_model()['w']
         query_vector = self._modelstorage.get_model()['query_vector']
 
-        for action_id in actions_id:
+        for action_id in action_ids:
             query_vector[action_id] = 0
-            w[action_id] = 1  # weight vector
+            w[action_id] = 1.0  # weight vector
 
         self._actions.extend(actions)
-        self._actions_id.extend(actions_id)

--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 
 class Exp3(BaseBandit):
 
-    """Exp3 with pre-trained supervised learning algorithm.
+    """Exp3 algorithm.
 
         Parameters
         ----------
@@ -163,7 +163,7 @@ class Exp3(BaseBandit):
             Parameters
             ----------
             actions : list
-                Actions (arms) for recommendation
+                A list of Action objects for recommendation
         """
 
         actions_id = [actions[i].action_id for i in range(len(actions))]

--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -70,18 +70,20 @@ class Exp3(BaseBandit):
             w = self._modelstorage.get_model()['w']
             w_sum = np.sum(w.values())
 
+            query_vector = {}
             for action_id in self._actions_id:
-                query_vector = (1 - self.gamma) * w[action_id] / w_sum + self.gamma / len(self._actions_id)
+                query_vector[action_id] = (1 - self.gamma) * w[action_id] / w_sum + self.gamma / len(self._actions_id)
 
             self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
 
             estimated_reward = {}
             uncertainty = {}
             score = {}
-            for i in range(self.k):
-                estimated_reward[self._actions_id[i]] = query_vector[i]
-                uncertainty[self._actions_id[i]] = 0
-                score[self._actions_id[i]] = query_vector[i]
+            for action_id in self._actions_id:
+                estimated_reward[action_id] = query_vector[action_id]
+                uncertainty[action_id] = 0
+                score[action_id] = query_vector[action_id]
+
             yield estimated_reward, uncertainty, score
 
         raise StopIteration
@@ -146,7 +148,7 @@ class Exp3(BaseBandit):
             for i in actions_id:
                 rhat[i] = 0.0
             rhat[action_id] = reward_tmp / query_vector[action_id]
-            w[action_id] *= np.exp(self.gamma * rhat / len(self._actions_id))
+            w[action_id] *= np.exp(self.gamma * rhat[action_id] / len(self._actions_id))
 
         self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
 

--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -41,7 +41,6 @@ class Exp3(BaseBandit):
     def __init__(self, actions, historystorage, modelstorage, gamma):
         super(Exp3, self).__init__(historystorage, modelstorage, actions)
 
-        self.n_actions = len(self._actions)  # number of actions (i.e. K in the paper)
         self.exp3_ = None
 
         # gamma in (0,1]
@@ -55,8 +54,11 @@ class Exp3(BaseBandit):
             self.gamma = gamma
 
         # Initialize the model storage
-        query_vector = np.zeros(self.n_actions)  # probability distribution for action recommendation)
-        w = np.ones(self.n_actions)  # weight vector
+        query_vector = {}
+        w = {}
+        for action_id in self._actions_id:
+            query_vector[action_id] = 0     # probability distribution for action recommendation)
+            w[action_id] = 1                # weight vector
         self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
 
     def exp3(self):
@@ -66,68 +68,107 @@ class Exp3(BaseBandit):
 
         while True:
             w = self._modelstorage.get_model()['w']
-            w_sum = np.sum(w)
-            query_vector = (1 - self.gamma) * w / w_sum + self.gamma / self.n_actions
+            w_sum = np.sum(w.values())
+
+            for action_id in self._actions_id:
+                query_vector = (1 - self.gamma) * w[action_id] / w_sum + self.gamma / len(self._actions_id)
 
             self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
 
-            action_idx = np.random.choice(np.arange(len(self._actions)), size=1, p=query_vector / sum(query_vector))[0]
-            action_max = self._actions[action_idx]
-            yield action_max
+            estimated_reward = {}
+            uncertainty = {}
+            score = {}
+            for i in range(self.k):
+                estimated_reward[self._actions_id[i]] = query_vector[i]
+                uncertainty[self._actions_id[i]] = 0
+                score[self._actions_id[i]] = query_vector[i]
+            yield estimated_reward, uncertainty, score
 
         raise StopIteration
 
-    def get_action(self, context):
-
+    def get_action(self, context, n_action=1):
         """Return the action to perform
 
-        Parameters
-        ----------
-        context : {array-like, None}
-            The context of current state, None if no context available.
+            Parameters
+            ----------
+            context : {array-like, None}
+                The context of current state, None if no context available.
 
-        Returns
-        -------
-        history_id : int
-            The history id of the action.
+            n_action: int
+                Number of actions wanted to recommend users.
 
-        action : Actions object
-            The action to perform.
+            Returns
+            -------
+            history_id : int
+                The history id of the action.
+
+            action : list of dictionaries
+                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
         """
 
         if self.exp3_ is None:
             self.exp3_ = self.exp3()
-            action_max = six.next(self.exp3_)
+            estimated_reward, uncertainty, score = six.next(self.exp3_)
         else:
-            action_max = six.next(self.exp3_)
+            estimated_reward, uncertainty, score = six.next(self.exp3_)
 
-        history_id = self._historystorage.add_history(np.transpose(np.array([context])), action_max, reward=None)
-        return history_id, action_max
+        action_recommend = []
+        actions_recommend_id = np.random.choice(self._actions_id, size=n_action, p=score.values(), replace=False)
+
+        for action_id in actions_recommend_id:
+            action_id = int(action_id)
+            action = [action for action in self._actions if action.action_id == action_id][0]
+            action_recommend.append({'action': action, 'estimated_reward': estimated_reward[action_id],
+                                     'uncertainty': uncertainty[action_id], 'score': score[action_id]})
+
+        history_id = self._historystorage.add_history(context, action_recommend, reward=None)
+        return history_id, action_recommend
 
     def reward(self, history_id, reward):
-        """Reward the preivous action with reward.
+        """Reward the previous action with reward.
 
-        Parameters
-        ----------
-        history_id : int
-            The history id of the action to reward.
+            Parameters
+            ----------
+            history_id : int
+                The history id of the action to reward.
 
-        reward : float
-            A float representing the feedback given to the action, the higher
-            the better.
+            reward : dictionary
+                The dictionary {action_id, reward}, where reward is a float.
         """
 
-        reward_action = self._historystorage.unrewarded_histories[history_id].action
-        reward_action_idx = self._actions.index(reward_action)
-        w_old = self._modelstorage.get_model()['w']
+        w = self._modelstorage.get_model()['w']
         query_vector = self._modelstorage.get_model()['query_vector']
+        actions_id = query_vector.keys()
 
         # Update the model
-        rhat = np.zeros(self.n_actions)
-        rhat[reward_action_idx] = reward / query_vector[reward_action_idx]
-        w_new = w_old * np.exp(self.gamma * rhat / self.n_actions)
+        for action_id, reward_tmp in reward.items():
+            rhat = {}
+            for i in actions_id:
+                rhat[i] = 0.0
+            rhat[action_id] = reward_tmp / query_vector[action_id]
+            w[action_id] *= np.exp(self.gamma * rhat / len(self._actions_id))
 
-        self._modelstorage.save_model({'query_vector': query_vector, 'w': w_new})
+        self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
 
         # Update the history
         self._historystorage.add_reward(history_id, reward)
+
+    def add_action(self, actions):
+        """ Add new actions (if needed).
+
+            Parameters
+            ----------
+            actions : list
+                Actions (arms) for recommendation
+        """
+
+        actions_id = [actions[i].action_id for i in range(len(actions))]
+        w = self._modelstorage.get_model()['w']
+        query_vector = self._modelstorage.get_model()['query_vector']
+
+        for action_id in actions_id:
+            query_vector[action_id] = 0
+            w[action_id] = 1  # weight vector
+
+        self._actions.extend(actions)
+        self._actions_id.extend(actions_id)

--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -20,10 +20,13 @@ class Exp3(BaseBandit):
         ----------
         actions : array-like
             Actions (arms) for recommendation.
+
         historystorage: a HistoryStorage object
             The place where we store the histories of contexts and rewards.
+
         modelstorage: a ModelStorage object
             The place where we store the model parameters.
+
         gamma: float, 0 < gamma <= 1
             The parameter used to control the minimum chosen probability for each action.
 
@@ -36,7 +39,7 @@ class Exp3(BaseBandit):
         ----------
         .. [1]  Peter Auer, Nicolo Cesa-Bianchi, et al. "The non-stochastic multi-armed bandit problem ."
                 SIAM Journal of Computing. 2002.
-        """
+    """
 
     def __init__(self, actions, historystorage, modelstorage, gamma):
         super(Exp3, self).__init__(historystorage, modelstorage, actions)
@@ -62,7 +65,6 @@ class Exp3(BaseBandit):
         self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
 
     def exp3(self):
-
         """The generator which implements the main part of Exp3.
         """
 

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -118,7 +118,7 @@ class Exp4P(BaseBandit):
                 The history id of the action.
 
             action : list of dictionaries
-                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
+                In each dictionary, it will contains {Action object, estimated_reward, uncertainty}
         """
 
         if self.exp4p_ is None:

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -84,8 +84,8 @@ class Exp4P(BaseBandit):
             w_sum = np.sum(w.values())
 
             query_vector = [(1 - self.k * self.pmin) *
-                     np.sum(np.array([w[i] * advice[i][action_id] for i in advisors_id])/w_sum) +
-                     self.pmin for action_id in self.actions_id]
+                            np.sum(np.array([w[i] * advice[i][action_id] for i in advisors_id])/w_sum) +
+                            self.pmin for action_id in self.actions_id]
             query_vector /= sum(query_vector)
             self._modelstorage.save_model({'query_vector': query_vector, 'w': w, 'advice': advice})
 
@@ -148,15 +148,15 @@ class Exp4P(BaseBandit):
 
     def reward(self, history_id, reward):
         """Reward the preivous action with reward.
+
         Parameters
         ----------
         history_id : int
             The history id of the action to reward.
-        reward : float
-            A float representing the feedback given to the action, the higher
-            the better.
+
+        reward : dictionary
+            The dictionary {action_id, reward}, where reward is a float.
         """
-        context = self._historystorage.unrewarded_histories[history_id].context
 
         w_old = self._modelstorage.get_model()['w']
         query_vector = self._modelstorage.get_model()['query_vector']
@@ -165,9 +165,9 @@ class Exp4P(BaseBandit):
         # Update the model
         w_new = {}
         for action_id, reward_tmp in reward.items():
-            rhat = np.zeros(self.k)
-            rhat[action_id] = reward/query_vector[action_id]
-            yhat = [np.dot(advice[i], rhat) for i in advice.keys()]
+            rhat = [{i: 0} for i in self._actions_id]
+            rhat[action_id] = reward_tmp/query_vector[action_id]
+            yhat = [np.dot(advice[i], rhat.values()) for i in advice.keys()]
             vhat = [sum([advice[i][action_id]/query_vector for action_id in self._actions_id]) for i in advice.keys()]
             for i in advice.keys():
                 w_new[i] = w_old[i] + np.exp(self.pmin / 2 * (

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -25,7 +25,7 @@ class Exp4P(BaseBandit):
         We strongly recommend to use scikit-learn package to pre-train the experts.
     delta: float, 0 < delta <= 1
         With probability 1 - delta, LinThompSamp satisfies the theoretical regret bound.
-    pmin: float, 0 < pmin < 1/n_actions
+    pmin: float, 0 < pmin < 1/k
         The minimum probability to choose each action.
     Attributes
     ----------
@@ -37,12 +37,11 @@ class Exp4P(BaseBandit):
             International Conference on Artificial Intelligence and Statistics (AISTATS). 2011u.
     """
 
-    def __init__(self, actions, historystorage, modelstorage, models, delta=0.1, pmin=None):
+    def __init__(self, actions, historystorage, modelstorage, delta=0.1, pmin=None):
         super(Exp4P, self).__init__(historystorage, modelstorage, actions)
         self.models = models
         self.n_total = 0
-        self.n_experts = len(self.models)           # number of experts (i.e. N in the paper)
-        self.n_actions = len(self._actions)          # number of actions (i.e. K in the paper)
+        self.k = len(self._actions)          # number of actions (i.e. K in the paper)
         self.exp4p_ = None
 
         # delta > 0
@@ -51,22 +50,22 @@ class Exp4P(BaseBandit):
                              "given is: %f" % pmin)
         self.delta = delta
 
-        # p_min in [0, 1/n_actions]
+        # p_min in [0, 1/k]
         if pmin is None:
-            self.pmin = np.sqrt(np.log(self.n_experts) / self.n_actions / 10000)
+            self.pmin = np.sqrt(np.log(10) / self.k / 10000)
         elif not isinstance(pmin, float):
             raise ValueError("pmin should be float, the one"
                              "given is: %f" % pmin)
-        elif (pmin < 0) or (pmin > (1. / self.n_actions)):
-            raise ValueError("pmin should be in [0, 1/n_actions], the one"
+        elif (pmin < 0) or (pmin > (1. / self.k)):
+            raise ValueError("pmin should be in [0, 1/k], the one"
                              "given is: %f" % pmin)
         else:
             self.pmin = pmin
 
         # Initialize the model storage
-        query_vector = np.zeros(self.n_actions)     # probability distribution for action recommendation)
-        w = np.ones(self.n_experts)                 # weight vector for each expert
-        advice = np.zeros((self.n_experts, self.n_actions))
+        query_vector = np.zeros(self.k)     # probability distribution for action recommendation)
+        w = {}              # weight vector for each expert
+        advice = None
         self._modelstorage.save_model({'query_vector': query_vector, 'w': w, 'advice': advice})
 
     def exp4p(self):
@@ -75,65 +74,77 @@ class Exp4P(BaseBandit):
         """
 
         while True:
-            context = yield
+            advice = yield
+            advisors_id = advice.keys()
 
-            advice = np.zeros((self.n_experts, self.n_actions))
-            # get the expert advice (probability)
-            for i, model in enumerate(self.models):
-                if len(model.classes_) != len(self._actions):
-                    proba = model.predict_proba([context])
-                    k = 0
-                    for action in self._actions:
-                        if action in model.classes_:
-                            action_idx = self._actions.index(action)
-                            advice[i, action_idx] = proba[0][k]
-                            k += 1
-                        else:
-                            action_idx = self._actions.index(action)
-                            advice[i, action_idx] = self.pmin
-                else:
-                    advice[i, :] = model.predict_proba([context])
-
-            # choice vector, shape = (self.K, )
             w = self._modelstorage.get_model()['w']
-            w_sum = np.sum(w)
-            p_temp = (1 - self.n_actions * self.pmin) * w / w_sum + self.pmin
+            if w == {}:
+                for i in advisors_id:
+                    w[i] = 1
+            w_sum = np.sum(w.values())
 
-            # query vector, shape= = (self.n_unlabeled, )
-            query_vector = np.dot(p_temp, advice)
+            query_vector = [(1 - self.k * self.pmin) *
+                     np.sum(np.array([w[i] * advice[i][action_id] for i in advisors_id])/w_sum) +
+                     self.pmin for action_id in self.actions_id]
+            query_vector /= sum(query_vector)
             self._modelstorage.save_model({'query_vector': query_vector, 'w': w, 'advice': advice})
 
-            # give back the
-            action_idx = np.random.choice(np.arange(len(self._actions)), size=1, p=query_vector/sum(query_vector))[0]
-            action_max = self._actions[action_idx]
-            yield action_max
+            estimated_reward = {}
+            uncertainty = {}
+            score = {}
+            for i in range(self.k):
+                estimated_reward[self._actions_id[i]] = query_vector[i]
+                uncertainty[self._actions_id[i]] = 0
+                score[self._actions_id[i]] = query_vector[i]
+            yield estimated_reward, uncertainty, score
 
         raise StopIteration
 
-    def get_action(self, context):
+    def get_action(self, context=None, n_action=1, advice=None):
         """Return the action to perform
-        Parameters
-        ----------
-        context : {array-like, None}
-            The context of current state, None if no context available.
-        Returns
-        -------
-        history_id : int
-            The history id of the action.
-        action : Actions object
-            The action to perform.
+
+            Parameters
+            ----------
+            context : {array-like, None}
+                The context of current state, None if no context available.
+
+            n_action: int
+                Number of actions wanted to recommend users.
+
+            advice: dictionary
+                The advice vectors from othe experts, {expert_id: advice_vectors}, where advice_vectors is
+                a dictionary {action_id: probability} predicted probability for each action.
+
+            Returns
+            -------
+            history_id : int
+                The history id of the action.
+
+            action : list of dictionaries
+                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
+
         """
+
         if self.exp4p_ is None:
             self.exp4p_ = self.exp4p()
             six.next(self.exp4p_)
-            action_max = self.exp4p_.send(context)
+            estimated_reward, uncertainty, score = self.exp4p_.send(advice)
         else:
             six.next(self.exp4p_)
-            action_max = self.exp4p_.send(context)
+            estimated_reward, uncertainty, score = self.exp4p_.send(advice)
+
+        action_recommend = []
+        actions_recommend_id = np.random.choice(self._actions_id, size=n_action, p=score, replace=False)
+
+        for action_id in actions_recommend_id:
+            action_id = int(action_id)
+            action = [action for action in self._actions if action.action_id == action_id][0]
+            action_recommend.append({'action': action, 'estimated_reward': estimated_reward[action_id],
+                                     'uncertainty': uncertainty[action_id], 'score': score[action_id]})
 
         self.n_total += 1
-        history_id = self._historystorage.add_history(np.transpose(np.array([context])), action_max, reward=None)
-        return history_id, action_max
+        history_id = self._historystorage.add_history(context, action_recommend, reward=None)
+        return history_id, action_recommend
 
     def reward(self, history_id, reward):
         """Reward the preivous action with reward.
@@ -145,31 +156,40 @@ class Exp4P(BaseBandit):
             A float representing the feedback given to the action, the higher
             the better.
         """
+        context = self._historystorage.unrewarded_histories[history_id].context
 
-        reward_action = self._historystorage.unrewarded_histories[history_id].action
-        reward_action_idx = self._actions.index(reward_action)
         w_old = self._modelstorage.get_model()['w']
         query_vector = self._modelstorage.get_model()['query_vector']
         advice = self._modelstorage.get_model()['advice']
 
         # Update the model
-        rhat = np.zeros(self.n_actions)
-        rhat[reward_action_idx] = reward/query_vector[reward_action_idx]
-        yhat = np.dot(advice, rhat)
-        vhat = np.zeros(self.n_experts)
-        for i in range(self.n_experts):
-            for j in range(self.n_actions):
-                vhat[i] = vhat[i] + advice[i, j] / query_vector[j]
-
-        w_new = w_old * np.exp(
-                           self.pmin / 2 * (
-                                yhat + vhat * np.sqrt(
-                                    np.log(self.n_experts / self.delta) / self.n_actions / self.n_total
-                                )
-                            )
+        w_new = {}
+        for action_id, reward_tmp in reward.items():
+            rhat = np.zeros(self.k)
+            rhat[action_id] = reward/query_vector[action_id]
+            yhat = [np.dot(advice[i], rhat) for i in advice.keys()]
+            vhat = [sum([advice[i][action_id]/query_vector for action_id in self._actions_id]) for i in advice.keys()]
+            for i in advice.keys():
+                w_new[i] = w_old[i] + np.exp(self.pmin / 2 * (
+                    yhat[i] + vhat[i] * np.sqrt(
+                        np.log(len(advice) / self.delta) / self.k / self.n_total
                         )
+                    )
+                )
 
         self._modelstorage.save_model({'query_vector': query_vector, 'w': w_new, 'advice': advice})
 
         # Update the history
         self._historystorage.add_reward(history_id, reward)
+
+    def add_action(self, actions):
+        """ Add new actions (if needed).
+
+            Parameters
+            ----------
+            actions : list
+                Actions (arms) for recommendation
+        """
+        actions_id = [actions[i].action_id for i in range(len(actions))]
+        self._actions.extend(actions)
+        self._actions_id.extend(actions_id)

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -194,7 +194,7 @@ class Exp4P(BaseBandit):
             Parameters
             ----------
             actions : list
-                Actions (arms) for recommendation
+                A list of Action objects for recommendation
         """
 
         actions_id = [actions[i].action_id for i in range(len(actions))]

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -11,6 +11,7 @@ LOGGER = logging.getLogger(__name__)
 
 class Exp4P(BaseBandit):
     """Exp4.P with pre-trained supervised learning algorithm.
+
     Parameters
     ----------
     actions : {array-like, None}
@@ -65,7 +66,7 @@ class Exp4P(BaseBandit):
 
         # Initialize the model storage
         query_vector = np.zeros(self.k)     # probability distribution for action recommendation)
-        w = {}              # weight vector for each expert
+        w = {}                              # weight vector for each expert
         self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
 
     def exp4p(self):
@@ -118,7 +119,6 @@ class Exp4P(BaseBandit):
 
             action : list of dictionaries
                 In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
-
         """
 
         if self.exp4p_ is None:
@@ -146,13 +146,13 @@ class Exp4P(BaseBandit):
     def reward(self, history_id, reward):
         """Reward the previous action with reward.
 
-        Parameters
-        ----------
-        history_id : int
-            The history id of the action to reward.
+            Parameters
+            ----------
+            history_id : int
+                The history id of the action to reward.
 
-        reward : dictionary
-            The dictionary {action_id, reward}, where reward is a float.
+            reward : dictionary
+                The dictionary {action_id, reward}, where reward is a float.
         """
 
         w_old = self._modelstorage.get_model()['w']
@@ -165,7 +165,6 @@ class Exp4P(BaseBandit):
             query_vector[actions_id[k]] = query_vector_tmp[k]
 
         # Update the model
-
         for action_id, reward_tmp in reward.items():
             rhat = {}
             for i in actions_id:
@@ -197,6 +196,7 @@ class Exp4P(BaseBandit):
             actions : list
                 Actions (arms) for recommendation
         """
+
         actions_id = [actions[i].action_id for i in range(len(actions))]
 
         self._actions.extend(actions)

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -156,9 +156,13 @@ class Exp4P(BaseBandit):
         """
 
         w_old = self._modelstorage.get_model()['w']
-        query_vector = self._modelstorage.get_model()['query_vector']
+        query_vector_tmp = self._modelstorage.get_model()['query_vector']
         context = self._historystorage.unrewarded_histories[history_id].context
         actions_id = context[context.keys()[0]].keys()
+
+        query_vector = {}
+        for k in range(len(query_vector_tmp)):
+            query_vector[actions_id[k]] = query_vector_tmp[k]
 
         # Update the model
 
@@ -172,7 +176,7 @@ class Exp4P(BaseBandit):
             rhat[action_id] = reward_tmp/query_vector[action_id]
             for i in context.keys():
                 yhat[i] = np.dot(context[i].values(), rhat.values())
-                vhat[i] = sum([context[i][k]/query_vector for k in actions_id])
+                vhat[i] = sum([context[i][k]/np.array(query_vector.values()) for k in actions_id])
                 w_new[i] = w_old[i] + np.exp(self.pmin / 2 * (
                     yhat[i] + vhat[i] * np.sqrt(
                         np.log(len(context) / self.delta) / self.k / self.n_total

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -11,7 +11,6 @@ LOGGER = logging.getLogger(__name__)
 
 class Exp4P(BaseBandit):
     """Exp4.P with pre-trained supervised learning algorithm.
-
     Parameters
     ----------
     actions : {array-like, None}
@@ -126,6 +125,7 @@ class Exp4P(BaseBandit):
             self.exp4p_ = self.exp4p()
             six.next(self.exp4p_)
             estimated_reward, uncertainty, score = self.exp4p_.send(context)
+
         else:
             six.next(self.exp4p_)
             estimated_reward, uncertainty, score = self.exp4p_.send(context)
@@ -193,7 +193,6 @@ class Exp4P(BaseBandit):
             actions : list
                 Actions (arms) for recommendation
         """
-        
         actions_id = [actions[i].action_id for i in range(len(actions))]
 
         self._actions.extend(actions)

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -12,32 +12,32 @@ LOGGER = logging.getLogger(__name__)
 class Exp4P(BaseBandit):
     """Exp4.P with pre-trained supervised learning algorithm.
 
-    Parameters
-    ----------
-    actions : {array-like, None}
-        Actions (arms) for recommendation
+        Parameters
+        ----------
+        actions : {array-like, None}
+            Actions (arms) for recommendation
 
-    historystorage: a HistoryStorage object
-        The place where we store the histories of contexts and rewards.
+        historystorage: a HistoryStorage object
+            The place where we store the histories of contexts and rewards.
 
-    modelstorage: a ModelStorage object
-        The place where we store the model parameters.
+        modelstorage: a ModelStorage object
+            The place where we store the model parameters.
 
-    delta: float, 0 < delta <= 1
-        With probability 1 - delta, LinThompSamp satisfies the theoretical regret bound.
+        delta: float, 0 < delta <= 1
+            With probability 1 - delta, LinThompSamp satisfies the theoretical regret bound.
 
-    pmin: float, 0 < pmin < 1/k
-        The minimum probability to choose each action.
+        pmin: float, 0 < pmin < 1/k
+            The minimum probability to choose each action.
 
-    Attributes
-    ----------
-    exp4p\_ : 'exp4p' object instance
-        The contextual bandit algorithm instances
+        Attributes
+        ----------
+        exp4p\_ : 'exp4p' object instance
+            The contextual bandit algorithm instances
 
-    References
-    ----------
-    .. [1]  Beygelzimer, Alina, et al. "Contextual bandit algorithms with supervised learning guarantees."
-            International Conference on Artificial Intelligence and Statistics (AISTATS). 2011u.
+        References
+        ----------
+        .. [1]  Beygelzimer, Alina, et al. "Contextual bandit algorithms with supervised learning guarantees."
+                International Conference on Artificial Intelligence and Statistics (AISTATS). 2011u.
     """
 
     def __init__(self, actions, historystorage, modelstorage, delta=0.1, pmin=None):

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -10,27 +10,30 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Exp4P(BaseBandit):
-
     """Exp4.P with pre-trained supervised learning algorithm.
+
     Parameters
     ----------
     actions : {array-like, None}
         Actions (arms) for recommendation
+
     historystorage: a HistoryStorage object
         The place where we store the histories of contexts and rewards.
+
     modelstorage: a ModelStorage object
         The place where we store the model parameters.
-    models: the list of pre-trained supervised learning model objects.
-        Use historical contents and rewards to train several multi-class classification models as experts.
-        We strongly recommend to use scikit-learn package to pre-train the experts.
+
     delta: float, 0 < delta <= 1
         With probability 1 - delta, LinThompSamp satisfies the theoretical regret bound.
+
     pmin: float, 0 < pmin < 1/k
         The minimum probability to choose each action.
+
     Attributes
     ----------
     exp4p\_ : 'exp4p' object instance
         The contextual bandit algorithm instances
+
     References
     ----------
     .. [1]  Beygelzimer, Alina, et al. "Contextual bandit algorithms with supervised learning guarantees."
@@ -67,7 +70,6 @@ class Exp4P(BaseBandit):
         self._modelstorage.save_model({'query_vector': query_vector, 'w': w})
 
     def exp4p(self):
-
         """The generator which implements the main part of Exp4.P.
         """
 
@@ -142,7 +144,7 @@ class Exp4P(BaseBandit):
         return history_id, action_recommend
 
     def reward(self, history_id, reward):
-        """Reward the preivous action with reward.
+        """Reward the previous action with reward.
 
         Parameters
         ----------
@@ -191,6 +193,7 @@ class Exp4P(BaseBandit):
             actions : list
                 Actions (arms) for recommendation
         """
+        
         actions_id = [actions[i].action_id for i in range(len(actions))]
 
         self._actions.extend(actions)

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -131,7 +131,7 @@ class Exp4P(BaseBandit):
             estimated_reward, uncertainty, score = self.exp4p_.send(context)
 
         action_recommend = []
-        actions_recommend_id = np.random.choice(self._actions_id, size=n_action, p=score.values(), replace=False)
+        actions_recommend_id = sorted(score, key=score.get, reverse=True)[:n_action]
 
         for action_id in actions_recommend_id:
             action_id = int(action_id)

--- a/striatum/bandit/linthompsamp.py
+++ b/striatum/bandit/linthompsamp.py
@@ -22,15 +22,20 @@ class LinThompSamp (BaseBandit):
     ----------
     actions : array-like
         Actions (arms) for recommendation.
+
     historystorage: a HistoryStorage object
         The object where we store the histories of contexts and rewards.
+
     modelstorage: a ModelStorage object
         The object where we store the model parameters.
+
     delta: float, 0 < delta < 1
         With probability 1 - delta, LinThompSamp satisfies the theoretical regret bound.
+
     r: float, r >= 0
         Assume that the residual ri(t) - bi(t)^T * muhat is r-sub-gaussian. In this case, r^2 represents the variance
         for residuals of the linear model bi(t)^T.
+
     epsilon: float, 0 < epsilon < 1
         A  parameter  used  by  the  Thompson Sampling algorithm. If the total trials T is known, we can choose
         epsilon = 1/ln(T)
@@ -82,6 +87,7 @@ class LinThompSamp (BaseBandit):
         f = np.matrix(np.zeros(self.d)).T
         self._modelstorage.save_model({'B': b, 'muhat': muhat, 'f': f})
 
+    @property
     def linthompsamp(self):
 
         while True:
@@ -91,60 +97,95 @@ class LinThompSamp (BaseBandit):
             muhat = self._modelstorage.get_model()['muhat']
             v = self.R * np.sqrt(24 / self.epsilon * self.d * np.log(self.t / self.delta))
             mu = np.random.multivariate_normal(np.array(muhat.T)[0], v**2 * np.linalg.inv(b), 1)[0]
-            action_max = self._actions[np.argmax(np.dot(np.array(context), np.array(mu)))]
-            yield action_max
+
+            estimated_reward = {}
+            uncertainty = {}
+            score = {}
+            for action_id in self._actions_id:
+                context_tmp = np.array(context[action_id])
+                estimated_reward[action_id] = float(np.dot(context_tmp, np.array(muhat)))
+                score[action_id] = float(np.dot(context_tmp, np.array(mu)))
+                uncertainty[action_id] = score[action_id] - estimated_reward[action_id]
+            yield estimated_reward, uncertainty, score
+
         raise StopIteration
 
-    def get_action(self, context):
+    def get_action(self, context, n_action=1):
         """Return the action to perform
+
         Parameters
         ----------
-        context : {matrix-like, None}
-            The context of all actions at the current state.
-            Row: action, Column: Context
+        context : dictionary
+            Contexts {action_id: context} of different actions.
+
+        n_action: int
+            Number of actions wanted to recommend users.
 
         Returns
         -------
         history_id : int
             The history id of the action.
-        action : Actions object
-            The action to perform.
+
+        action : list of dictionaries
+            In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
         """
         if context is None:
             raise ValueError("LinThompSamp requires contexts for all actions!")
 
         if self.linthompsamp_ is None:
-            self.linthompsamp_ = self.linthompsamp()
+            self.linthompsamp_ = self.linthompsamp
             six.next(self.linthompsamp_)
-            action_max = self.linthompsamp_.send(context)
+            estimated_reward, uncertainty, score = self.linthompsamp_.send(context)
         else:
             six.next(self.linthompsamp_)
-            action_max = self.linthompsamp_.send(context)
+            estimated_reward, uncertainty, score = self.linthompsamp_.send(context)
 
-        history_id = self._historystorage.add_history(context, action_max, reward=None)
-        return history_id, action_max
+        action_recommend = []
+        actions_recommend_id = [self._actions_id[i] for i in np.array(score.values()).argsort()[-n_action:][::-1]]
+        for action_id in actions_recommend_id:
+            action_id = int(action_id)
+            action = [action for action in self._actions if action.action_id == action_id][0]
+            action_recommend.append({'action': action, 'estimated_reward': estimated_reward[action_id],
+                                     'uncertainty': uncertainty[action_id], 'score': score[action_id]})
+
+        history_id = self._historystorage.add_history(context, action_recommend, reward=None)
+        return history_id, action_recommend
 
     def reward(self, history_id, reward):
         """Reward the previous action with reward.
+
         Parameters
         ----------
         history_id : int
             The history id of the action to reward.
-        reward : float
-            A float representing the feedback given to the action, the higher
-            the better.
+
+        reward : dictionary
+            The dictionary {action_id, reward}, where reward is a float.
         """
         context = self._historystorage.unrewarded_histories[history_id].context
-        reward_action = self._historystorage.unrewarded_histories[history_id].action
-        reward_action_idx = self._actions.index(reward_action)
 
         # Update the model
         b = self._modelstorage.get_model()['B']
         f = self._modelstorage.get_model()['f']
-        b += np.dot(np.matrix(context)[reward_action_idx].T, np.matrix(context)[reward_action_idx])
-        f += reward * np.matrix(context)[reward_action_idx].T
-        muhat = np.dot(np.linalg.inv(b), f)
+
+        for action_id, reward_tmp in reward.items():
+            context_tmp = np.matrix(context[action_id])
+            b += np.dot(context_tmp.T, context_tmp)
+            f += reward_tmp * context_tmp.T
+            muhat = np.dot(np.linalg.inv(b), f)
         self._modelstorage.save_model({'B': b, 'muhat': muhat, 'f': f})
 
         # Update the history
         self._historystorage.add_reward(history_id, reward)
+
+    def add_action(self, actions):
+        """ Add new actions (if needed).
+
+            Parameters
+            ----------
+            actions : list
+                Actions (arms) for recommendation
+        """
+        actions_id = [actions[i].action_id for i in range(len(actions))]
+        self._actions.extend(actions)
+        self._actions_id.extend(actions_id)

--- a/striatum/bandit/linthompsamp.py
+++ b/striatum/bandit/linthompsamp.py
@@ -1,5 +1,8 @@
 """ Thompson Sampling with Linear Payoff
-In This module contains a class that implements Thompson Sampling with Linear Payoff, a contextual bandit algorithm.
+In This module contains a class that implements Thompson Sampling with Linear Payoff.
+Thompson Sampling with linear payoff is a contexutal multi-armed bandit algorithm which assume the underlying
+relationship between rewards and contexts is linear. The sampling method is used to balance the exploration and
+exploitation. Please check the reference for more details.
 """
 
 import numpy as np
@@ -12,43 +15,39 @@ LOGGER = logging.getLogger(__name__)
 
 class LinThompSamp (BaseBandit):
 
-    """Thompson Sampling with Linear Payoff:
+    """Thompson Sampling with Linear Payoff.
 
-    Thompson Sampling with linear payoff is a contexutal multi-armed bandit algorithm which assume the underlying
-    relationship between rewards and contexts is linear. The sampling method is used to balance the exploration and
-    exploitation. Please check the reference for more details.
+        Parameters
+        ----------
+        actions : array-like
+            Actions (arms) for recommendation.
 
-    Parameters
-    ----------
-    actions : array-like
-        Actions (arms) for recommendation.
+        historystorage: a HistoryStorage object
+            The object where we store the histories of contexts and rewards.
 
-    historystorage: a HistoryStorage object
-        The object where we store the histories of contexts and rewards.
+        modelstorage: a ModelStorage object
+            The object where we store the model parameters.
 
-    modelstorage: a ModelStorage object
-        The object where we store the model parameters.
+        delta: float, 0 < delta < 1
+            With probability 1 - delta, LinThompSamp satisfies the theoretical regret bound.
 
-    delta: float, 0 < delta < 1
-        With probability 1 - delta, LinThompSamp satisfies the theoretical regret bound.
+        r: float, r >= 0
+            Assume that the residual ri(t) - bi(t)^T * muhat is r-sub-gaussian. In this case, r^2 represents
+            the variance for residuals of the linear model bi(t)^T.
 
-    r: float, r >= 0
-        Assume that the residual ri(t) - bi(t)^T * muhat is r-sub-gaussian. In this case, r^2 represents the variance
-        for residuals of the linear model bi(t)^T.
+        epsilon: float, 0 < epsilon < 1
+            A  parameter  used  by  the  Thompson Sampling algorithm. If the total trials T is known, we can choose
+            epsilon = 1/ln(T)
 
-    epsilon: float, 0 < epsilon < 1
-        A  parameter  used  by  the  Thompson Sampling algorithm. If the total trials T is known, we can choose
-        epsilon = 1/ln(T)
+        Attributes
+        ----------
+        linthomp\_ : 'linthomp' object instance
+            The contextual bandit algorithm instances
 
-    Attributes
-    ----------
-    linthomp\_ : 'linthomp' object instance
-        The contextual bandit algorithm instances
-
-    References
-    ----------
-    .. [1]  Shipra Agrawal, and Navin Goyal. "Thompson Sampling for Contextual Bandits with Linear Payoffs."
-            Advances in Neural Information Processing Systems 24. 2011.
+        References
+        ----------
+        .. [1]  Shipra Agrawal, and Navin Goyal. "Thompson Sampling for Contextual Bandits with Linear Payoffs."
+                Advances in Neural Information Processing Systems 24. 2011.
     """
 
     def __init__(self, actions, historystorage, modelstorage, d, delta=0.5, r=0.5, epsilon=0.1):
@@ -186,7 +185,7 @@ class LinThompSamp (BaseBandit):
             Parameters
             ----------
             actions : list
-                Actions (arms) for recommendation
+                A list of Action objects for recommendation
         """
         actions_id = [actions[i].action_id for i in range(len(actions))]
         self._actions.extend(actions)

--- a/striatum/bandit/linthompsamp.py
+++ b/striatum/bandit/linthompsamp.py
@@ -142,7 +142,7 @@ class LinThompSamp (BaseBandit):
             estimated_reward, uncertainty, score = self.linthompsamp_.send(context)
 
         action_recommend = []
-        actions_recommend_id = [self._actions_id[i] for i in np.array(score.values()).argsort()[-n_action:][::-1]]
+        actions_recommend_id = sorted(score, key=score.get, reverse=True)[:n_action]
         for action_id in actions_recommend_id:
             action_id = int(action_id)
             action = [action for action in self._actions if action.action_id == action_id][0]

--- a/striatum/bandit/linthompsamp.py
+++ b/striatum/bandit/linthompsamp.py
@@ -128,7 +128,7 @@ class LinThompSamp (BaseBandit):
                 The history id of the action.
 
             action : list of dictionaries
-                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
+                In each dictionary, it will contains {Action object, estimated_reward, uncertainty}
         """
 
         if context is None:

--- a/striatum/bandit/linthompsamp.py
+++ b/striatum/bandit/linthompsamp.py
@@ -113,22 +113,23 @@ class LinThompSamp (BaseBandit):
     def get_action(self, context, n_action=1):
         """Return the action to perform
 
-        Parameters
-        ----------
-        context : dictionary
-            Contexts {action_id: context} of different actions.
+            Parameters
+            ----------
+            context : dictionary
+                Contexts {action_id: context} of different actions.
 
-        n_action: int
-            Number of actions wanted to recommend users.
+            n_action: int
+                Number of actions wanted to recommend users.
 
-        Returns
-        -------
-        history_id : int
-            The history id of the action.
+            Returns
+            -------
+            history_id : int
+                The history id of the action.
 
-        action : list of dictionaries
-            In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
+            action : list of dictionaries
+                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
         """
+
         if context is None:
             raise ValueError("LinThompSamp requires contexts for all actions!")
 
@@ -154,13 +155,13 @@ class LinThompSamp (BaseBandit):
     def reward(self, history_id, reward):
         """Reward the previous action with reward.
 
-        Parameters
-        ----------
-        history_id : int
-            The history id of the action to reward.
+            Parameters
+            ----------
+            history_id : int
+                The history id of the action to reward.
 
-        reward : dictionary
-            The dictionary {action_id, reward}, where reward is a float.
+            reward : dictionary
+                The dictionary {action_id, reward}, where reward is a float.
         """
         context = self._historystorage.unrewarded_histories[history_id].context
 

--- a/striatum/bandit/linthompsamp.py
+++ b/striatum/bandit/linthompsamp.py
@@ -90,7 +90,7 @@ class LinThompSamp (BaseBandit):
 
         while True:
             context = yield
-            actions_id = context.keys()
+            action_ids = context.keys()
             context_tmp = np.matrix(context.values())
             b = self._modelstorage.get_model()['B']
             muhat = self._modelstorage.get_model()['muhat']
@@ -102,10 +102,10 @@ class LinThompSamp (BaseBandit):
             estimated_reward = {}
             uncertainty = {}
             score = {}
-            for i in range(len(actions_id)):
-                estimated_reward[actions_id[i]] = float(estimated_reward_tmp[i][0])
-                score[actions_id[i]] = float(score_tmp[i])
-                uncertainty[actions_id[i]] = score[actions_id[i]] - estimated_reward[actions_id[i]]
+            for i in range(len(action_ids)):
+                estimated_reward[action_ids[i]] = float(estimated_reward_tmp[i][0])
+                score[action_ids[i]] = float(score_tmp[i])
+                uncertainty[action_ids[i]] = score[action_ids[i]] - estimated_reward[action_ids[i]]
             yield estimated_reward, uncertainty, score
 
         raise StopIteration
@@ -189,6 +189,5 @@ class LinThompSamp (BaseBandit):
             A list of Action objects for recommendation
         """
 
-        actions_id = [actions[i].action_id for i in range(len(actions))]
+        action_ids = [actions[i].action_id for i in range(len(actions))]
         self._actions.extend(actions)
-        self._actions_id.extend(actions_id)

--- a/striatum/bandit/linucb.py
+++ b/striatum/bandit/linucb.py
@@ -16,26 +16,30 @@ class LinUCB(BaseBandit):
 
     Parameters
     ----------
-    actions : {array-like, None}
-        Actions (arms) for recommendation
-    historystorage: a :py:mod:'striatum.storage.HistoryStorage' object
-        The object where we store the histories of contexts and rewards.
-    modelstorage: a :py:mod:'straitum.storage.ModelStorage' object
-        The object where we store the model parameters.
-    alpha: float
-        The constant determines the width of the upper confidence bound.
-    d: int
-        The dimension of the context.
+        actions : {array-like, None}
+            Actions (arms) for recommendation
 
-    Attributes
-    ----------
-    linucb\_ : 'linucb' object instance
-        The contextual bandit algorithm instances,
+        historystorage: a :py:mod:'striatum.storage.HistoryStorage' object
+            The object where we store the histories of contexts and rewards.
 
-    References
-    ----------
-    .. [1]  Lihong Li, et al. "A Contextual-Bandit Approach to Personalized News Article Recommendation."
-            Proceedings of the 19th International Conference on World Wide Web (WWW), 2010.
+        modelstorage: a :py:mod:'straitum.storage.ModelStorage' object
+            The object where we store the model parameters.
+
+        alpha: float
+            The constant determines the width of the upper confidence bound.
+
+        d: int
+            The dimension of the context.
+
+        Attributes
+        ----------
+        linucb\_ : 'linucb' object instance
+            The contextual bandit algorithm instances,
+
+        References
+        ----------
+        .. [1]  Lihong Li, et al. "A Contextual-Bandit Approach to Personalized News Article Recommendation."
+                In Proceedings of the 19th International Conference on World Wide Web (WWW), 2010.
     """
 
     def __init__(self, actions, historystorage, modelstorage, alpha, d=1):
@@ -85,22 +89,23 @@ class LinUCB(BaseBandit):
     def get_action(self, context, n_action=1):
         """Return the action to perform
 
-        Parameters
-        ----------
-        context : dictionary
-            Contexts {action_id: context} of different actions.
+            Parameters
+            ----------
+            context : dictionary
+                Contexts {action_id: context} of different actions.
 
-        n_action: int
-            Number of actions wanted to recommend users.
+            n_action: int
+                Number of actions wanted to recommend users.
 
-        Returns
-        -------
-        history_id : int
-            The history id of the action.
+            Returns
+            -------
+            history_id : int
+                The history id of the action.
 
-        action : list of dictionaries
-            In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
+            action_recommend : list of dictionaries
+                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
         """
+
         if context is None:
             raise ValueError("LinUCB requires contexts for all actions!")
 
@@ -126,14 +131,15 @@ class LinUCB(BaseBandit):
     def reward(self, history_id, reward):
         """Reward the previous action with reward.
 
-        Parameters
-        ----------
-        history_id : int
-            The history id of the action to reward.
+            Parameters
+            ----------
+            history_id : int
+                The history id of the action to reward.
 
-        reward : dictionary
-            The dictionary {action_id, reward}, where reward is a float.
+            reward : dictionary
+                The dictionary {action_id, reward}, where reward is a float.
         """
+
         context = self._historystorage.unrewarded_histories[history_id].context
 
         # Update the model
@@ -161,6 +167,7 @@ class LinUCB(BaseBandit):
             actions : {array-like, None}
                 Actions (arms) for recommendation
         """
+
         actions_id = [actions[i].action_id for i in range(len(actions))]
         self._actions.extend(actions)
         self._actions_id.extend(actions_id)

--- a/striatum/bandit/linucb.py
+++ b/striatum/bandit/linucb.py
@@ -14,8 +14,8 @@ LOGGER = logging.getLogger(__name__)
 class LinUCB(BaseBandit):
     """LinUCB with Disjoint Linear Models
 
-    Parameters
-    ----------
+        Parameters
+        ----------
         actions : {array-like, None}
             Actions (arms) for recommendation
 
@@ -34,7 +34,7 @@ class LinUCB(BaseBandit):
         Attributes
         ----------
         linucb\_ : 'linucb' object instance
-            The contextual bandit algorithm instances,
+            The contextual bandit algorithm instances.
 
         References
         ----------
@@ -164,8 +164,8 @@ class LinUCB(BaseBandit):
 
             Parameters
             ----------
-            actions : {array-like, None}
-                Actions (arms) for recommendation
+            actions : list
+                A list of Action objects for recommendation
         """
 
         actions_id = [actions[i].action_id for i in range(len(actions))]

--- a/striatum/bandit/linucb.py
+++ b/striatum/bandit/linucb.py
@@ -118,7 +118,7 @@ class LinUCB(BaseBandit):
             estimated_reward, uncertainty, score = self.linucb_.send(context)
 
         action_recommend = []
-        actions_recommend_id = [self._actions_id[i] for i in np.array(score.values()).argsort()[-n_action:][::-1]]
+        actions_recommend_id = sorted(score, key=score.get, reverse=True)[:n_action]
         for action_id in actions_recommend_id:
             action_id = int(action_id)
             action = [action for action in self._actions if action.action_id == action_id][0]

--- a/striatum/bandit/linucb.py
+++ b/striatum/bandit/linucb.py
@@ -161,17 +161,20 @@ class LinUCB(BaseBandit):
             actions : {array-like, None}
                 Actions (arms) for recommendation
         """
+        actions_id = [actions[i].action_id for i in range(len(actions))]
+        self._actions.append(actions)
+        self._actions_id.extend(actions_id)
+
         matrix_a = self._modelstorage.get_model()['matrix_a']
         matrix_ainv = self._modelstorage.get_model()['matrix_ainv']
         b = self._modelstorage.get_model()['b']
         theta = self._modelstorage.get_model()['theta']
 
-        for key in actions:
-            if key not in self._actions:
-                matrix_a[key] = np.identity(self.d)
-                matrix_ainv[key] = np.identity(self.d)
-                b[key] = np.zeros((self.d, 1))
-                theta[key] = np.zeros((self.d, 1))
+        for action_id in actions_id:
+            if action_id not in self._actions_id:
+                matrix_a[action_id] = np.identity(self.d)
+                matrix_ainv[action_id] = np.identity(self.d)
+                b[action_id] = np.zeros((self.d, 1))
+                theta[action_id] = np.zeros((self.d, 1))
 
-        self._actions.extend(actions)
         self._modelstorage.save_model({'matrix_a': matrix_a, 'matrix_ainv': matrix_ainv, 'b': b, 'theta': theta})

--- a/striatum/bandit/linucb.py
+++ b/striatum/bandit/linucb.py
@@ -55,7 +55,7 @@ class LinUCB(BaseBandit):
         b = {}  # dictionary - The cumulative return of action a, given the context xt.
         theta = {}  # dictionary - The coefficient vector of actiona with linear model b = dot(xt, theta)
 
-        for action_id in self._actions_id:
+        for action_id in self.action_ids:
             matrix_a[action_id] = np.identity(self.d)
             matrix_ainv[action_id] = np.identity(self.d)
             b[action_id] = np.zeros((self.d, 1))
@@ -76,7 +76,7 @@ class LinUCB(BaseBandit):
             estimated_reward = {}
             uncertainty = {}
             score = {}
-            for action_id in self._actions_id:
+            for action_id in self.action_ids:
                 context_tmp = np.array(context[action_id])
                 estimated_reward[action_id] = float(np.dot(context_tmp, theta_tmp[action_id]))
                 uncertainty[action_id] = float(self.alpha * np.sqrt(
@@ -168,16 +168,15 @@ class LinUCB(BaseBandit):
             A list of Action objects for recommendation
         """
 
-        actions_id = [actions[i].action_id for i in range(len(actions))]
+        action_ids = [actions[i].action_id for i in range(len(actions))]
         self._actions.extend(actions)
-        self._actions_id.extend(actions_id)
 
         matrix_a = self._modelstorage.get_model()['matrix_a']
         matrix_ainv = self._modelstorage.get_model()['matrix_ainv']
         b = self._modelstorage.get_model()['b']
         theta = self._modelstorage.get_model()['theta']
 
-        for action_id in actions_id:
+        for action_id in action_ids:
                 matrix_a[action_id] = np.identity(self.d)
                 matrix_ainv[action_id] = np.identity(self.d)
                 b[action_id] = np.zeros((self.d, 1))

--- a/striatum/bandit/linucb.py
+++ b/striatum/bandit/linucb.py
@@ -103,7 +103,7 @@ class LinUCB(BaseBandit):
                 The history id of the action.
 
             action_recommend : list of dictionaries
-                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
+                In each dictionary, it will contains {Action object, estimated_reward, uncertainty}
         """
 
         if context is None:

--- a/striatum/bandit/tests/test_exp3.py
+++ b/striatum/bandit/tests/test_exp3.py
@@ -27,42 +27,42 @@ class TestExp3(unittest.TestCase):
 
     def test_get_first_action(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id, action = policy.get_action(context=None, n_action=1)
+        history_id, action = policy.get_action(context=None, n_actions=1)
         self.assertEqual(history_id, 0)
         self.assertIn(action[0]['action'], self.actions)
 
     def test_update_reward(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id, action = policy.get_action(context=None, n_action=1)
+        history_id, action = policy.get_action(context=None, n_actions=1)
         policy.reward(history_id, {1: 1.0})
         self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 1.0})
 
     def test_model_storage(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id, action = policy.get_action(context=None, n_action=1)
+        history_id, action = policy.get_action(context=None, n_actions=1)
         policy.reward(history_id, {1: 1.0})
         self.assertEqual(len(policy._modelstorage._model['w']), 5)
         self.assertEqual(len(policy._modelstorage._model['query_vector']), 5)
 
     def test_delay_reward(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id1, action1 = policy.get_action(context=None, n_action=1)
-        history_id2, action2 = policy.get_action(context=None, n_action=1)
+        history_id1, action1 = policy.get_action(context=None, n_actions=1)
+        history_id2, action2 = policy.get_action(context=None, n_actions=1)
         policy.reward(history_id1, {1: 1.0})
         self.assertEqual(policy._historystorage.get_history(history_id1).reward, {1: 1.0})
         self.assertEqual(policy._historystorage.get_history(history_id2).reward, None)
 
     def test_reward_order_descending(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id1, action1 = policy.get_action(context=None, n_action=1)
-        history_id2, action2 = policy.get_action(context=None, n_action=1)
+        history_id1, action1 = policy.get_action(context=None, n_actions=1)
+        history_id2, action2 = policy.get_action(context=None, n_actions=1)
         policy.reward(history_id2, {1: 1.0, 2: 0.0})
         self.assertEqual(policy._historystorage.get_history(history_id1).reward, None)
         self.assertEqual(policy._historystorage.get_history(history_id2).reward, {1: 1.0, 2: 0.0})
 
     def test_add_action(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id, action = policy.get_action(context=None, n_action=1)
+        history_id, action = policy.get_action(context=None, n_actions=1)
         a6 = Action(6, 'a6', 'how are you?')
         a7 = Action(7, 'a7', 'i am fine')
         policy.add_action([a6, a7])

--- a/striatum/bandit/tests/test_exp3.py
+++ b/striatum/bandit/tests/test_exp3.py
@@ -12,11 +12,11 @@ class TestExp3(unittest.TestCase):
     def setUp(self):
         self.modelstorage = model.MemoryModelStorage()
         self.historystorage = history.MemoryHistoryStorage()
-        a1 = Action(1, 'a1', 'i love u')
-        a2 = Action(2, 'a2', 'i hate u')
-        a3 = Action(3, 'a3', 'i do not understand')
-        a4 = Action(4, 'a4', 'i love u very much')
-        a5 = Action(5, 'a5', 'i hate u very nuch')
+        a1 = Action(1)
+        a2 = Action(2)
+        a3 = Action(3)
+        a4 = Action(4)
+        a5 = Action(5)
         self.actions = [a1, a2, a3, a4, a5]
         self.gamma = 0.5
 
@@ -63,8 +63,8 @@ class TestExp3(unittest.TestCase):
     def test_add_action(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
         history_id, action = policy.get_action(context=None, n_actions=1)
-        a6 = Action(6, 'a6', 'how are you?')
-        a7 = Action(7, 'a7', 'i am fine')
+        a6 = Action(6)
+        a7 = Action(7)
         policy.add_action([a6, a7])
         policy.reward(history_id, {3: 1})
         self.assertEqual(len(policy._actions), 7)

--- a/striatum/bandit/tests/test_exp3.py
+++ b/striatum/bandit/tests/test_exp3.py
@@ -60,6 +60,16 @@ class TestExp3(unittest.TestCase):
         self.assertEqual(policy._historystorage.get_history(history_id1).reward, None)
         self.assertEqual(policy._historystorage.get_history(history_id2).reward, {1: 1.0, 2: 0.0})
 
+    def test_add_action(self):
+        policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
+        history_id, action = policy.get_action(context=None, n_action=1)
+        a6 = Action(6, 'a6', 'how are you?')
+        a7 = Action(7, 'a7', 'i am fine')
+        policy.add_action([a6, a7])
+        policy.reward(history_id, {3: 1})
+        self.assertEqual(len(policy._actions), 7)
+        self.assertEqual(policy._actions_id, [1, 2, 3, 4, 5, 6, 7])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/striatum/bandit/tests/test_exp3.py
+++ b/striatum/bandit/tests/test_exp3.py
@@ -68,7 +68,7 @@ class TestExp3(unittest.TestCase):
         policy.add_action([a6, a7])
         policy.reward(history_id, {3: 1})
         self.assertEqual(len(policy._actions), 7)
-        self.assertEqual(policy._actions_id, [1, 2, 3, 4, 5, 6, 7])
+        self.assertEqual(policy.action_ids, [1, 2, 3, 4, 5, 6, 7])
 
 
 if __name__ == '__main__':

--- a/striatum/bandit/tests/test_exp3.py
+++ b/striatum/bandit/tests/test_exp3.py
@@ -5,13 +5,19 @@ sys.path.append("..")
 from striatum.storage import history as history
 from striatum.storage import model as model
 from striatum.bandit import exp3
+from striatum.bandit.bandit import Action
 
 
 class TestExp3(unittest.TestCase):
     def setUp(self):
         self.modelstorage = model.MemoryModelStorage()
         self.historystorage = history.MemoryHistoryStorage()
-        self.actions = [1, 2, 3, 4, 5]
+        a1 = Action(1, 'a1', 'i love u')
+        a2 = Action(2, 'a2', 'i hate u')
+        a3 = Action(3, 'a3', 'i do not understand')
+        a4 = Action(4, 'a4', 'i love u very much')
+        a5 = Action(5, 'a5', 'i hate u very nuch')
+        self.actions = [a1, a2, a3, a4, a5]
         self.gamma = 0.5
 
     def test_initialization(self):
@@ -21,46 +27,38 @@ class TestExp3(unittest.TestCase):
 
     def test_get_first_action(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id, action = policy.get_action([1, 1])
+        history_id, action = policy.get_action(context=None, n_action=1)
         self.assertEqual(history_id, 0)
-        self.assertIn(action, self.actions)
+        self.assertIn(action[0]['action'], self.actions)
 
     def test_update_reward(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id, action = policy.get_action([1, 1])
-        policy.reward(history_id, 1.0)
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, 1.0)
+        history_id, action = policy.get_action(context=None, n_action=1)
+        policy.reward(history_id, {1: 1.0})
+        self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 1.0})
 
     def test_model_storage(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id, action = policy.get_action([1, 1])
-        policy.reward(history_id, 1.0)
+        history_id, action = policy.get_action(context=None, n_action=1)
+        policy.reward(history_id, {1: 1.0})
         self.assertEqual(len(policy._modelstorage._model['w']), 5)
         self.assertEqual(len(policy._modelstorage._model['query_vector']), 5)
 
     def test_delay_reward(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id, action = policy.get_action([1, 1])
-        history_id_2, action_2 = policy.get_action([3, 3])
-        policy.reward(history_id, 1)
-        self.assertTrue(
-            (policy._historystorage.get_history(history_id).context == np.transpose(np.array([[1, 1]]))).all())
-        self.assertTrue(
-            (policy._historystorage.get_history(history_id_2).context == np.transpose(np.array([[3, 3]]))).all())
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, 1)
-        self.assertEqual(policy._historystorage.get_history(history_id_2).reward, None)
+        history_id1, action1 = policy.get_action(context=None, n_action=1)
+        history_id2, action2 = policy.get_action(context=None, n_action=1)
+        policy.reward(history_id1, {1: 1.0})
+        self.assertEqual(policy._historystorage.get_history(history_id1).reward, {1: 1.0})
+        self.assertEqual(policy._historystorage.get_history(history_id2).reward, None)
 
     def test_reward_order_descending(self):
         policy = exp3.Exp3(self.actions, self.historystorage, self.modelstorage, self.gamma)
-        history_id, action = policy.get_action([1, 1])
-        history_id_2, action_2 = policy.get_action([3, 3])
-        policy.reward(history_id_2, 1)
-        self.assertTrue(
-            (policy._historystorage.get_history(history_id).context == np.transpose(np.array([[1, 1]]))).all())
-        self.assertTrue(
-            (policy._historystorage.get_history(history_id_2).context == np.transpose(np.array([[3, 3]]))).all())
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, None)
-        self.assertEqual(policy._historystorage.get_history(history_id_2).reward, 1)
+        history_id1, action1 = policy.get_action(context=None, n_action=1)
+        history_id2, action2 = policy.get_action(context=None, n_action=1)
+        policy.reward(history_id2, {1: 1.0, 2: 0.0})
+        self.assertEqual(policy._historystorage.get_history(history_id1).reward, None)
+        self.assertEqual(policy._historystorage.get_history(history_id2).reward, {1: 1.0, 2: 0.0})
 
 
 if __name__ == '__main__':

--- a/striatum/bandit/tests/test_exp4p.py
+++ b/striatum/bandit/tests/test_exp4p.py
@@ -21,7 +21,7 @@ class Exp4P(unittest.TestCase):
         a4 = Action(4, 'a4', 'i love u very much')
         a5 = Action(5, 'a5', 'i hate u very nuch')
         self.actions = [a1, a2, a3, a4, a5]
-        self.actions_id = [1, 2, 3, 4, 5]
+        self.action_ids = [1, 2, 3, 4, 5]
 
     def test_initialization(self):
         policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, pmin=None)
@@ -98,7 +98,7 @@ class Exp4P(unittest.TestCase):
         policy.add_action([a6, a7])
         policy.reward(history_id, {3: 1})
         self.assertEqual(len(policy._actions), 7)
-        self.assertEqual(policy._actions_id, [1, 2, 3, 4, 5, 6, 7])
+        self.assertEqual(policy.action_ids, [1, 2, 3, 4, 5, 6, 7])
 
 
 if __name__ == '__main__':

--- a/striatum/bandit/tests/test_exp4p.py
+++ b/striatum/bandit/tests/test_exp4p.py
@@ -15,11 +15,11 @@ class Exp4P(unittest.TestCase):
     def setUp(self):
         self.modelstorage = model.MemoryModelStorage()
         self.historystorage = history.MemoryHistoryStorage()
-        a1 = Action(1, 'a1', 'i love u')
-        a2 = Action(2, 'a2', 'i hate u')
-        a3 = Action(3, 'a3', 'i do not understand')
-        a4 = Action(4, 'a4', 'i love u very much')
-        a5 = Action(5, 'a5', 'i hate u very nuch')
+        a1 = Action(1)
+        a2 = Action(2)
+        a3 = Action(3)
+        a4 = Action(4)
+        a5 = Action(5)
         self.actions = [a1, a2, a3, a4, a5]
         self.action_ids = [1, 2, 3, 4, 5]
 
@@ -93,8 +93,8 @@ class Exp4P(unittest.TestCase):
         prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
         context = {1: prob1, 2: prob2}
         history_id, action = policy.get_action(context, 2)
-        a6 = Action(6, 'a6', 'how are you?')
-        a7 = Action(7, 'a7', 'i am fine')
+        a6 = Action(6)
+        a7 = Action(7)
         policy.add_action([a6, a7])
         policy.reward(history_id, {3: 1})
         self.assertEqual(len(policy._actions), 7)

--- a/striatum/bandit/tests/test_exp4p.py
+++ b/striatum/bandit/tests/test_exp4p.py
@@ -8,78 +8,97 @@ sys.path.append("..")
 from striatum.storage import history as history
 from striatum.storage import model as model
 from striatum.bandit import exp4p
+from striatum.bandit.bandit import Action
 
 
 class Exp4P(unittest.TestCase):
     def setUp(self):
         self.modelstorage = model.MemoryModelStorage()
         self.historystorage = history.MemoryHistoryStorage()
-        self.actions = [1, 2, 3, 4, 5]
-        self.history_context = np.random.uniform(0, 5, (1000, 2))
-        self.history_action = np.zeros(1000)
-        for t in range(1000):
-            for i in range(5):
-                if i * 2 < sum(self.history_context[t, :]) <= (i + 1) * 2:
-                    self.history_action[t] = self.actions[i]
-        self.LogReg = OneVsRestClassifier(LogisticRegression())
-        self.MNB = OneVsRestClassifier(MultinomialNB())
-        self.LogReg.fit(self.history_context, self.history_action)
-        self.MNB.fit(self.history_context, self.history_action)
+        a1 = Action(1, 'a1', 'i love u')
+        a2 = Action(2, 'a2', 'i hate u')
+        a3 = Action(3, 'a3', 'i do not understand')
+        a4 = Action(4, 'a4', 'i love u very much')
+        a5 = Action(5, 'a5', 'i hate u very nuch')
+        self.actions = [a1, a2, a3, a4, a5]
+        self.actions_id = [1, 2, 3, 4, 5]
 
     def test_initialization(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage,
-                             [self.LogReg, self.MNB], delta=0.1, pmin=None)
+        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, pmin=None)
         self.assertEqual(self.actions, policy._actions)
         self.assertEqual(0.1, policy.delta)
 
     def test_get_first_action(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage,
-                             [self.LogReg, self.MNB], delta=0.1, pmin=None)
-        history_id, action = policy.get_action([1, 1])
+        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, pmin=None)
+        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+        context = {1: prob1, 2: prob2}
+        history_id, action = policy.get_action(context, 1)
         self.assertEqual(history_id, 0)
-        self.assertIn(action, self.actions)
+        self.assertIn(action[0]['action'], self.actions)
+        self.assertEqual(policy._historystorage.get_history(history_id).context, context)
 
     def test_update_reward(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage,
-                             [self.LogReg, self.MNB], delta=0.1, pmin=None)
-        history_id, action = policy.get_action([1, 1])
-        policy.reward(history_id, 1.0)
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, 1.0)
+        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, pmin=None)
+        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+        context = {1: prob1, 2: prob2}
+        history_id, action = policy.get_action(context, 1)
+        policy.reward(history_id, {1: 1.0})
+        self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 1.0})
 
     def test_model_storage(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage,
-                             [self.LogReg, self.MNB], delta=0.1, pmin=None)
-        history_id, action = policy.get_action([1, 1])
-        policy.reward(history_id, 1.0)
+        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, pmin=None)
+        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+        context = {1: prob1, 2: prob2}
+        history_id, action = policy.get_action(context, 1)
+        policy.reward(history_id, {1: 1.0})
         self.assertEqual(len(policy._modelstorage._model['w']), 2)
         self.assertEqual(len(policy._modelstorage._model['query_vector']), 5)
-        self.assertEqual(np.shape(policy._modelstorage._model['advice']), (2, 5))
 
     def test_delay_reward(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage,
-                             [self.LogReg, self.MNB], delta=0.1, pmin=None)
-        history_id, action = policy.get_action([1, 1])
-        history_id_2, action_2 = policy.get_action([3, 3])
-        policy.reward(history_id, 1)
-        self.assertTrue(
-            (policy._historystorage.get_history(history_id).context == np.transpose(np.array([[1, 1]]))).all())
-        self.assertTrue(
-            (policy._historystorage.get_history(history_id_2).context == np.transpose(np.array([[3, 3]]))).all())
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, 1)
-        self.assertEqual(policy._historystorage.get_history(history_id_2).reward, None)
+        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, pmin=None)
+        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+        context1 = {1: prob1, 2: prob2}
+        history_id1, action1 = policy.get_action(context1, 1)
+        prob1 = {1: 0.32, 2: 0.51, 3: 0.05, 4: 0.06, 5: 0.06}
+        prob2 = {1: 0.32, 2: 0.42, 3: 0.12, 4: 0.07, 5: 0.07}
+        context2 = {1: prob1, 2: prob2}
+        history_id2, action2 = policy.get_action(context2, 2)
+        policy.reward(history_id1, {1: 1.0})
+        self.assertEqual(policy._historystorage.get_history(history_id1).context, context1)
+        self.assertEqual(policy._historystorage.get_history(history_id2).context, context2)
+        self.assertEqual(policy._historystorage.get_history(history_id1).reward, {1: 1.0})
+        self.assertEqual(policy._historystorage.get_history(history_id2).reward, None)
 
     def test_reward_order_descending(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage,
-                             [self.LogReg, self.MNB], delta=0.1, pmin=None)
-        history_id, action = policy.get_action([1, 1])
-        history_id_2, action_2 = policy.get_action([3, 3])
-        policy.reward(history_id_2, 1)
-        self.assertTrue(
-            (policy._historystorage.get_history(history_id).context == np.transpose(np.array([[1, 1]]))).all())
-        self.assertTrue(
-            (policy._historystorage.get_history(history_id_2).context == np.transpose(np.array([[3, 3]]))).all())
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, None)
-        self.assertEqual(policy._historystorage.get_history(history_id_2).reward, 1)
+        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, pmin=None)
+        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+        context1 = {1: prob1, 2: prob2}
+        history_id1, action1 = policy.get_action(context1, 1)
+        prob1 = {1: 0.32, 2: 0.51, 3: 0.05, 4: 0.06, 5: 0.06}
+        prob2 = {1: 0.32, 2: 0.42, 3: 0.12, 4: 0.07, 5: 0.07}
+        context2 = {1: prob1, 2: prob2}
+        history_id2, action2 = policy.get_action(context2, 2)
+        policy.reward(history_id2, {1: 1.0, 2: 1.0})
+        self.assertEqual(policy._historystorage.get_history(history_id1).reward, None)
+        self.assertEqual(policy._historystorage.get_history(history_id2).reward, {1: 1.0, 2: 1.0})
+
+    def test_add_action(self):
+        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, pmin=None)
+        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+        context = {1: prob1, 2: prob2}
+        history_id, action = policy.get_action(context, 2)
+        a6 = Action(6, 'a6', 'how are you?')
+        a7 = Action(7, 'a7', 'i am fine')
+        policy.add_action([a6, a7])
+        policy.reward(history_id, {3: 1})
+        self.assertEqual(len(policy._actions), 7)
+        self.assertEqual(policy._actions_id, [1, 2, 3, 4, 5, 6, 7])
 
 
 if __name__ == '__main__':

--- a/striatum/bandit/tests/test_linthompsamp.py
+++ b/striatum/bandit/tests/test_linthompsamp.py
@@ -4,13 +4,16 @@ sys.path.append("..")
 from striatum.storage import history as history
 from striatum.storage import model as model
 from striatum.bandit import linthompsamp
-
+from striatum.bandit.bandit import Action
 
 class TestLinThompSamp(unittest.TestCase):
     def setUp(self):
         self.modelstorage = model.MemoryModelStorage()
         self.historystorage = history.MemoryHistoryStorage()
-        self.actions = [1, 2, 3]
+        a1 = Action(1, 'a1', 'i love u')
+        a2 = Action(2, 'a2', 'i hate u')
+        a3 = Action(3, 'a3', 'i do not understand')
+        self.actions = [a1, a2, a3]
         self.d = 2
         self.delta = 0.5
         self.R = 0.5
@@ -27,23 +30,26 @@ class TestLinThompSamp(unittest.TestCase):
     def test_get_first_action(self):
         policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
                                            self.modelstorage, self.d, self.delta, self.R, self.epsilon)
-        history_id, action = policy.get_action([[1, 1], [2, 2], [3, 3]])
+        context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        history_id, action = policy.get_action(context, 1)
         self.assertEqual(history_id, 0)
-        self.assertIn(action, self.actions)
-        self.assertTrue((policy._historystorage.get_history(history_id).context == [[1, 1], [2, 2], [3, 3]]))
+        self.assertIn(action[0]['action'], self.actions)
+        self.assertEqual(policy._historystorage.get_history(history_id).context, context)
 
     def test_update_reward(self):
         policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
                                            self.modelstorage, self.d, self.delta, self.R, self.epsilon)
-        history_id, action = policy.get_action([[1, 1], [2, 2], [3, 3]])
-        policy.reward(history_id, 1.0)
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, 1)
+        context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        history_id, action = policy.get_action(context, 1)
+        policy.reward(history_id, {3: 1})
+        self.assertEqual(policy._historystorage.get_history(history_id).reward, {3: 1})
 
     def test_model_storage(self):
         policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
                                            self.modelstorage, self.d, self.delta, self.R, self.epsilon)
-        history_id, action = policy.get_action([[1, 1], [2, 2], [3, 3]])
-        policy.reward(history_id, 1.0)
+        context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        history_id, action = policy.get_action(context, 2)
+        policy.reward(history_id, {2: 1, 3: 1})
         self.assertTrue((policy._modelstorage._model['B'].shape == (2, 2)) == True)
         self.assertEqual(len(policy._modelstorage._model['muhat']), 2)
         self.assertEqual(len(policy._modelstorage._model['f']), 2)
@@ -51,24 +57,40 @@ class TestLinThompSamp(unittest.TestCase):
     def test_delay_reward(self):
         policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
                                            self.modelstorage, self.d, self.delta, self.R, self.epsilon)
-        history_id, action = policy.get_action([[1, 1], [2, 2], [3, 3]])
-        history_id_2, action_2 = policy.get_action([[0, 1], [2, 3], [7, 5]])
-        policy.reward(history_id, 1)
-        self.assertEqual(policy._historystorage.get_history(history_id).context, [[1, 1], [2, 2], [3, 3]])
-        self.assertEqual(policy._historystorage.get_history(history_id_2).context, [[0, 1], [2, 3], [7, 5]])
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, 1)
-        self.assertEqual(policy._historystorage.get_history(history_id_2).reward, None)
+        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        context2 = {1: [0, 0], 2: [3, 3], 3: [6, 6]}
+        history_id1, action1 = policy.get_action(context1, 2)
+        history_id2, action2 = policy.get_action(context2, 1)
+        policy.reward(history_id1, {2: 1, 3: 1})
+        self.assertEqual(policy._historystorage.get_history(history_id1).context, context1)
+        self.assertEqual(policy._historystorage.get_history(history_id2).context, context2)
+        self.assertEqual(policy._historystorage.get_history(history_id1).reward, {2: 1, 3: 1})
+        self.assertEqual(policy._historystorage.get_history(history_id2).reward, None)
 
     def test_reward_order_descending(self):
         policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
                                            self.modelstorage, self.d, self.delta, self.R, self.epsilon)
-        history_id, action = policy.get_action([[1, 1], [2, 2], [3, 3]])
-        history_id_2, action_2 = policy.get_action([[0, 1], [2, 3], [7, 5]])
-        policy.reward(history_id_2, 1)
-        self.assertEqual(policy._historystorage.get_history(history_id).context, [[1, 1], [2, 2], [3, 3]])
-        self.assertEqual(policy._historystorage.get_history(history_id_2).context, [[0, 1], [2, 3], [7, 5]])
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, None)
-        self.assertEqual(policy._historystorage.get_history(history_id_2).reward, 1)
+        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        context2 = {1: [0, 0], 2: [3, 3], 3: [6, 6]}
+        history_id1, action1 = policy.get_action(context1, 2)
+        history_id2, action2 = policy.get_action(context2, 1)
+        policy.reward(history_id2, {3: 1})
+        self.assertEqual(policy._historystorage.get_history(history_id1).context, context1)
+        self.assertEqual(policy._historystorage.get_history(history_id2).context, context2)
+        self.assertEqual(policy._historystorage.get_history(history_id1).reward, None)
+        self.assertEqual(policy._historystorage.get_history(history_id2).reward, {3: 1})
+
+    def test_add_action(self):
+        policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
+                                           self.modelstorage, self.d, self.delta, self.R, self.epsilon)
+        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        history_id, action = policy.get_action(context1, 2)
+        a4 = Action(4, 'a4', 'how are you?')
+        a5 = Action(5, 'a5', 'i am fine')
+        policy.add_action([a4, a5])
+        policy.reward(history_id, {3: 1})
+        self.assertEqual(len(policy._actions), 5)
+        self.assertEqual(policy._actions_id, [1, 2, 3, 4, 5])
 
 
 if __name__ == '__main__':

--- a/striatum/bandit/tests/test_linthompsamp.py
+++ b/striatum/bandit/tests/test_linthompsamp.py
@@ -90,7 +90,7 @@ class TestLinThompSamp(unittest.TestCase):
         policy.add_action([a4, a5])
         policy.reward(history_id, {3: 1})
         self.assertEqual(len(policy._actions), 5)
-        self.assertEqual(policy._actions_id, [1, 2, 3, 4, 5])
+        self.assertEqual(policy.action_ids, [1, 2, 3, 4, 5])
 
 
 if __name__ == '__main__':

--- a/striatum/bandit/tests/test_linthompsamp.py
+++ b/striatum/bandit/tests/test_linthompsamp.py
@@ -10,9 +10,9 @@ class TestLinThompSamp(unittest.TestCase):
     def setUp(self):
         self.modelstorage = model.MemoryModelStorage()
         self.historystorage = history.MemoryHistoryStorage()
-        a1 = Action(1, 'a1', 'i love u')
-        a2 = Action(2, 'a2', 'i hate u')
-        a3 = Action(3, 'a3', 'i do not understand')
+        a1 = Action(1)
+        a2 = Action(2)
+        a3 = Action(3)
         self.actions = [a1, a2, a3]
         self.d = 2
         self.delta = 0.5
@@ -85,8 +85,8 @@ class TestLinThompSamp(unittest.TestCase):
                                            self.modelstorage, self.d, self.delta, self.R, self.epsilon)
         context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
         history_id, action = policy.get_action(context1, 2)
-        a4 = Action(4, 'a4', 'how are you?')
-        a5 = Action(5, 'a5', 'i am fine')
+        a4 = Action(4)
+        a5 = Action(5)
         policy.add_action([a4, a5])
         policy.reward(history_id, {3: 1})
         self.assertEqual(len(policy._actions), 5)

--- a/striatum/bandit/tests/test_linucb.py
+++ b/striatum/bandit/tests/test_linucb.py
@@ -13,9 +13,9 @@ class TestLinUcb(unittest.TestCase):
     def setUp(self):
         self.modelstorage = model.MemoryModelStorage()
         self.historystorage = history.MemoryHistoryStorage()
-        a1 = Action(1, 'a1', 'i love u')
-        a2 = Action(2, 'a2', 'i hate u')
-        a3 = Action(3, 'a3', 'i do not understand')
+        a1 = Action(1)
+        a2 = Action(2)
+        a3 = Action(3)
         self.actions = [a1, a2, a3]
         self.alpha = 1.00
 
@@ -85,8 +85,8 @@ class TestLinUcb(unittest.TestCase):
                                self.modelstorage, 1.00, 2)
         context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
         history_id, action = policy.get_action(context1, 2)
-        a4 = Action(4, 'a4', 'how are you?')
-        a5 = Action(5, 'a5', 'i am fine')
+        a4 = Action(4)
+        a5 = Action(5)
         policy.add_action([a4, a5])
         policy.reward(history_id, {3: 1})
         self.assertTrue((policy._modelstorage.get_model()['matrix_a'][4] == np.identity(2)).all())

--- a/striatum/bandit/tests/test_linucb.py
+++ b/striatum/bandit/tests/test_linucb.py
@@ -24,7 +24,7 @@ class TestLinUcb(unittest.TestCase):
         self.assertEqual(self.actions, policy._actions)
         self.assertEqual(1.00, policy.alpha)
         self.assertEqual(2, policy.d)
-        self.assertEqual([1, 2, 3], policy._actions_id)
+        self.assertEqual([1, 2, 3], policy.action_ids)
 
     def test_get_first_action(self):
         policy = linucb.LinUCB(self.actions, self.historystorage,

--- a/striatum/bandit/tests/test_ucb1.py
+++ b/striatum/bandit/tests/test_ucb1.py
@@ -59,6 +59,16 @@ class Ucb1(unittest.TestCase):
         self.assertEqual(policy._historystorage.get_history(history_id).reward, None)
         self.assertEqual(policy._historystorage.get_history(history_id_2).reward, {1: 0, 2: 0})
 
+    def test_add_action(self):
+        policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
+        history_id, action = policy.get_action(context=None, n_action=1)
+        a6 = Action(6, 'a6', 'how are you?')
+        a7 = Action(7, 'a7', 'i am fine')
+        policy.add_action([a6, a7])
+        policy.reward(history_id, {3: 1})
+        self.assertEqual(len(policy._actions), 7)
+        self.assertEqual(policy._actions_id, [1, 2, 3, 4, 5, 6, 7])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/striatum/bandit/tests/test_ucb1.py
+++ b/striatum/bandit/tests/test_ucb1.py
@@ -67,7 +67,7 @@ class Ucb1(unittest.TestCase):
         policy.add_action([a6, a7])
         policy.reward(history_id, {3: 1})
         self.assertEqual(len(policy._actions), 7)
-        self.assertEqual(policy._actions_id, [1, 2, 3, 4, 5, 6, 7])
+        self.assertEqual(policy.action_ids, [1, 2, 3, 4, 5, 6, 7])
 
 
 if __name__ == '__main__':

--- a/striatum/bandit/tests/test_ucb1.py
+++ b/striatum/bandit/tests/test_ucb1.py
@@ -4,13 +4,19 @@ sys.path.append("..")
 from striatum.storage import history as history
 from striatum.storage import model as model
 from striatum.bandit import ucb1
+from striatum.bandit.bandit import Action
 
 
 class Ucb1(unittest.TestCase):
     def setUp(self):
         self.modelstorage = model.MemoryModelStorage()
         self.historystorage = history.MemoryHistoryStorage()
-        self.actions = [1, 2, 3, 4, 5]
+        a1 = Action(1, 'a1', 'i love u')
+        a2 = Action(2, 'a2', 'i hate u')
+        a3 = Action(3, 'a3', 'i do not understand')
+        a4 = Action(4, 'a4', 'i love u very much')
+        a5 = Action(5, 'a5', 'i hate u very nuch')
+        self.actions = [a1, a2, a3, a4, a5]
         self.alpha = 1.00
 
     def test_initialization(self):
@@ -19,39 +25,39 @@ class Ucb1(unittest.TestCase):
 
     def test_get_first_action(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None)
+        history_id, action = policy.get_action(context=None, n_action=1)
         self.assertEqual(history_id, 0)
-        self.assertIn(action, self.actions)
+        self.assertIn(action[0]['action'], self.actions)
 
     def test_update_reward(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None)
-        policy.reward(history_id, 1)
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, 1)
+        history_id, action = policy.get_action(context=None, n_action=1)
+        policy.reward(history_id, {1: 0})
+        self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 0})
 
     def test_model_storage(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None)
-        policy.reward(history_id, 1)
-        self.assertEqual(policy._modelstorage._model['empirical_reward'][action], 2)
-        self.assertEqual(policy._modelstorage._model['n_actions'][action], 2.0)
+        history_id, action = policy.get_action(context=None, n_action=1)
+        policy.reward(history_id, {action[0]['action'].action_id: 1.0})
+        self.assertEqual(policy._modelstorage._model['empirical_reward'][action[0]['action'].action_id], 2)
+        self.assertEqual(policy._modelstorage._model['n_actions'][action[0]['action'].action_id], 2.0)
         self.assertEqual(policy._modelstorage._model['n_total'], 6.0)
 
     def test_delay_reward(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None)
-        history_id_2, action_2 = policy.get_action(context=None)
-        policy.reward(history_id, 1)
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, 1.0)
+        history_id, action = policy.get_action(context=None, n_action=1)
+        history_id_2, action_2 = policy.get_action(context=None, n_action=1)
+        policy.reward(history_id, {1: 0})
+        self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 0})
         self.assertEqual(policy._historystorage.get_history(history_id_2).reward, None)
 
     def test_reward_order_descending(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None)
-        history_id_2, action_2 = policy.get_action(context=None)
-        policy.reward(history_id_2, 1)
+        history_id, action = policy.get_action(context=None, n_action=1)
+        history_id_2, action_2 = policy.get_action(context=None, n_action=2)
+        policy.reward(history_id_2, {1: 0, 2: 0})
         self.assertEqual(policy._historystorage.get_history(history_id).reward, None)
-        self.assertEqual(policy._historystorage.get_history(history_id_2).reward, 1.0)
+        self.assertEqual(policy._historystorage.get_history(history_id_2).reward, {1: 0, 2: 0})
 
 
 if __name__ == '__main__':

--- a/striatum/bandit/tests/test_ucb1.py
+++ b/striatum/bandit/tests/test_ucb1.py
@@ -25,43 +25,43 @@ class Ucb1(unittest.TestCase):
 
     def test_get_first_action(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_action=1)
+        history_id, action = policy.get_action(context=None, n_actions=1)
         self.assertEqual(history_id, 0)
         self.assertIn(action[0]['action'], self.actions)
 
     def test_update_reward(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_action=1)
+        history_id, action = policy.get_action(context=None, n_actions=1)
         policy.reward(history_id, {1: 0})
         self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 0})
 
     def test_model_storage(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_action=1)
+        history_id, action = policy.get_action(context=None, n_actions=1)
         policy.reward(history_id, {action[0]['action'].action_id: 1.0})
         self.assertEqual(policy._modelstorage._model['empirical_reward'][action[0]['action'].action_id], 2)
-        self.assertEqual(policy._modelstorage._model['n_actions'][action[0]['action'].action_id], 2.0)
-        self.assertEqual(policy._modelstorage._model['n_total'], 6.0)
+        self.assertEqual(policy._modelstorage._model['action_times'][action[0]['action'].action_id], 2.0)
+        self.assertEqual(policy._modelstorage._model['total_time'], 6.0)
 
     def test_delay_reward(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_action=1)
-        history_id_2, action_2 = policy.get_action(context=None, n_action=1)
+        history_id, action = policy.get_action(context=None, n_actions=1)
+        history_id_2, action_2 = policy.get_action(context=None, n_actions=1)
         policy.reward(history_id, {1: 0})
         self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 0})
         self.assertEqual(policy._historystorage.get_history(history_id_2).reward, None)
 
     def test_reward_order_descending(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_action=1)
-        history_id_2, action_2 = policy.get_action(context=None, n_action=2)
+        history_id, action = policy.get_action(context=None, n_actions=1)
+        history_id_2, action_2 = policy.get_action(context=None, n_actions=2)
         policy.reward(history_id_2, {1: 0, 2: 0})
         self.assertEqual(policy._historystorage.get_history(history_id).reward, None)
         self.assertEqual(policy._historystorage.get_history(history_id_2).reward, {1: 0, 2: 0})
 
     def test_add_action(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_action=1)
+        history_id, action = policy.get_action(context=None, n_actions=1)
         a6 = Action(6, 'a6', 'how are you?')
         a7 = Action(7, 'a7', 'i am fine')
         policy.add_action([a6, a7])

--- a/striatum/bandit/tests/test_ucb1.py
+++ b/striatum/bandit/tests/test_ucb1.py
@@ -11,11 +11,11 @@ class Ucb1(unittest.TestCase):
     def setUp(self):
         self.modelstorage = model.MemoryModelStorage()
         self.historystorage = history.MemoryHistoryStorage()
-        a1 = Action(1, 'a1', 'i love u')
-        a2 = Action(2, 'a2', 'i hate u')
-        a3 = Action(3, 'a3', 'i do not understand')
-        a4 = Action(4, 'a4', 'i love u very much')
-        a5 = Action(5, 'a5', 'i hate u very nuch')
+        a1 = Action(1)
+        a2 = Action(2)
+        a3 = Action(3)
+        a4 = Action(4)
+        a5 = Action(5)
         self.actions = [a1, a2, a3, a4, a5]
         self.alpha = 1.00
 
@@ -62,8 +62,8 @@ class Ucb1(unittest.TestCase):
     def test_add_action(self):
         policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
         history_id, action = policy.get_action(context=None, n_actions=1)
-        a6 = Action(6, 'a6', 'how are you?')
-        a7 = Action(7, 'a7', 'i am fine')
+        a6 = Action(6)
+        a7 = Action(7)
         policy.add_action([a6, a7])
         policy.reward(history_id, {3: 1})
         self.assertEqual(len(policy._actions), 7)

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -80,7 +80,7 @@ class UCB1(BaseBandit):
                 The history id of the action.
 
             action : list of dictionaries
-                In each dictionary, it will contains {rank: Action object, estimated_reward, uncertainty}
+                In each dictionary, it will contains {Action object, estimated_reward, uncertainty}
         """
 
         if self.ucb1_ is None:

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -14,75 +14,75 @@ class UCB1(BaseBandit):
 
     """Upper Confidence Bound 1
 
-        Parameters
-        ----------
-        actions : {array-like, None}
-            Actions (arms) for recommendation
+    Parameters
+    ----------
+    actions : {array-like, None}
+        Actions (arms) for recommendation
 
-        historystorage: a :py:mod:'striatum.storage.HistoryStorage' object
-            The object where we store the histories of contexts and rewards.
+    historystorage: a :py:mod:'striatum.storage.HistoryStorage' object
+        The object where we store the histories of contexts and rewards.
 
-        modelstorage: a :py:mod:'straitum.storage.ModelStorage' object
-            The object where we store the model parameters.
+    modelstorage: a :py:mod:'straitum.storage.ModelStorage' object
+        The object where we store the model parameters.
 
-        Attributes
-        ----------
-        ucb1\_ : 'ucb1' object instance
-            The multi-armed bandit algorithm instances.
+    Attributes
+    ----------
+    ucb1\_ : 'ucb1' object instance
+        The multi-armed bandit algorithm instances.
 
-        References
-        ----------
-        .. [1]  Peter Auer, et al. "Finite-time Analysis of the Multiarmed Bandit Problem."
-                Machine Learning, 47. 2002.
+    References
+    ----------
+    .. [1]  Peter Auer, et al. "Finite-time Analysis of the Multiarmed Bandit Problem."
+            Machine Learning, 47. 2002.
     """
 
     def __init__(self, actions, historystorage, modelstorage):
         super(UCB1, self).__init__(historystorage, modelstorage, actions)
         self.ucb1_ = None
         empirical_reward = {}
-        n_actions = {}
+        action_times = {}
         for action_id in self._actions_id:
             empirical_reward[action_id] = 1.0
-            n_actions[action_id] = 1.0
-        n_total = float(len(self._actions))
+            action_times[action_id] = 1.0
+        total_time = float(len(self._actions))
         self._modelstorage.save_model({'empirical_reward': empirical_reward,
-                                      'n_actions': n_actions, 'n_total': n_total})
+                                      'action_times': action_times, 'total_time': total_time})
 
     def ucb1(self):
         while True:
             empirical_reward = self._modelstorage.get_model()['empirical_reward']
-            n_actions = self._modelstorage.get_model()['n_actions']
-            n_total = self._modelstorage.get_model()['n_total']
+            action_times = self._modelstorage.get_model()['action_times']
+            total_time = self._modelstorage.get_model()['total_time']
 
             estimated_reward = {}
             uncertainty = {}
             score = {}
             for action_id in self._actions_id:
-                estimated_reward[action_id] = empirical_reward[action_id]/n_actions[action_id]
-                uncertainty[action_id] = np.sqrt(2*np.log(n_total)/n_actions[action_id])
+                estimated_reward[action_id] = empirical_reward[action_id]/action_times[action_id]
+                uncertainty[action_id] = np.sqrt(2*np.log(total_time)/action_times[action_id])
                 score[action_id] = estimated_reward[action_id] + uncertainty[action_id]
             yield estimated_reward, uncertainty, score
 
         raise StopIteration
 
-    def get_action(self, context, n_action=1):
+    def get_action(self, context, n_actions=1):
         """Return the action to perform
 
-            Parameters
-            ----------
-            context : {array-like, None}
-                The context of current state, None if no context available.
+        Parameters
+        ----------
+        context : {array-like, None}
+            The context of current state, None if no context available.
 
-            n_action: int
-                Number of actions wanted to recommend users.
+        n_actions: int
+            Number of actions wanted to recommend users.
 
-            Returns
-            -------
-            history_id : int
-                The history id of the action.
+        Returns
+        -------
+        history_id : int
+            The history id of the action.
 
-            action : list of dictionaries
-                In each dictionary, it will contains {Action object, estimated_reward, uncertainty}
+        action : list of dictionaries
+            In each dictionary, it will contains {Action object, estimated_reward, uncertainty}
         """
 
         if self.ucb1_ is None:
@@ -91,61 +91,61 @@ class UCB1(BaseBandit):
         else:
             estimated_reward, uncertainty, score = six.next(self.ucb1_)
 
-        action_recommend = []
-        actions_recommend_id = sorted(score, key=score.get, reverse=True)[:n_action]
-        for action_id in actions_recommend_id:
+        action_recommendation = []
+        actions_recommendation_ids = sorted(score, key=score.get, reverse=True)[:n_actions]
+        for action_id in actions_recommendation_ids:
             action_id = int(action_id)
             action = [action for action in self._actions if action.action_id == action_id][0]
-            action_recommend.append({'action': action, 'estimated_reward': estimated_reward[action_id],
+            action_recommendation.append({'action': action, 'estimated_reward': estimated_reward[action_id],
                                      'uncertainty': uncertainty[action_id], 'score': score[action_id]})
 
-        history_id = self._historystorage.add_history(context, action_recommend, reward=None)
-        return history_id, action_recommend
+        history_id = self._historystorage.add_history(context, action_recommendation, reward=None)
+        return history_id, action_recommendation
 
-    def reward(self, history_id, reward):
+    def reward(self, history_id, rewards):
         """Reward the previous action with reward.
 
-            Parameters
-            ----------
-            history_id : int
-                The history id of the action to reward.
+        Parameters
+        ----------
+        history_id : int
+            The history id of the action to reward.
 
-            reward : dictionary
-                The dictionary {action_id, reward}, where reward is a float.
+        rewards : dictionary
+            The dictionary {action_id, reward}, where reward is a float.
         """
 
         # Update the model
         empirical_reward = self._modelstorage.get_model()['empirical_reward']
-        n_actions = self._modelstorage.get_model()['n_actions']
-        n_total = self._modelstorage.get_model()['n_total']
-        for action_id, reward_tmp in reward.items():
+        action_times = self._modelstorage.get_model()['action_times']
+        total_time = self._modelstorage.get_model()['total_time']
+        for action_id, reward_tmp in rewards.items():
             empirical_reward[action_id] += reward_tmp
-            n_actions[action_id] += 1.0
-            n_total += 1.0
+            action_times[action_id] += 1.0
+            total_time += 1.0
             self._modelstorage.save_model({'empirical_reward': empirical_reward,
-                                           'n_actions': n_actions, 'n_total': n_total})
+                                           'action_times': action_times, 'total_time': total_time})
         # Update the history
-        self._historystorage.add_reward(history_id, reward)
+        self._historystorage.add_reward(history_id, rewards)
 
     def add_action(self, actions):
         """ Add new actions (if needed).
 
-            Parameters
-            ----------
-            actions : list
-                A list of Action objects for recommendation
+        Parameters
+        ----------
+        actions : iterable
+            A list of Action objects for recommendation
         """
         actions_id = [actions[i].action_id for i in range(len(actions))]
         self._actions.extend(actions)
         self._actions_id.extend(actions_id)
 
         empirical_reward = self._modelstorage.get_model()['empirical_reward']
-        n_actions = self._modelstorage.get_model()['n_actions']
-        n_total = self._modelstorage.get_model()['n_total']
+        action_times = self._modelstorage.get_model()['action_times']
+        total_time = self._modelstorage.get_model()['total_time']
 
         for action_id in self._actions_id:
             empirical_reward[action_id] = 1.0
-            n_actions[action_id] = 1.0
+            action_times[action_id] = 1.0
 
         self._modelstorage.save_model({'empirical_reward': empirical_reward,
-                                       'n_actions': n_actions, 'n_total': n_total})
+                                       'action_times': action_times, 'total_time': total_time})

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -41,7 +41,7 @@ class UCB1(BaseBandit):
         self.ucb1_ = None
         empirical_reward = {}
         action_times = {}
-        for action_id in self._actions_id:
+        for action_id in self.action_ids:
             empirical_reward[action_id] = 1.0
             action_times[action_id] = 1.0
         total_time = float(len(self._actions))
@@ -57,7 +57,7 @@ class UCB1(BaseBandit):
             estimated_reward = {}
             uncertainty = {}
             score = {}
-            for action_id in self._actions_id:
+            for action_id in self.action_ids:
                 estimated_reward[action_id] = empirical_reward[action_id]/action_times[action_id]
                 uncertainty[action_id] = np.sqrt(2*np.log(total_time)/action_times[action_id])
                 score[action_id] = estimated_reward[action_id] + uncertainty[action_id]
@@ -135,15 +135,14 @@ class UCB1(BaseBandit):
         actions : iterable
             A list of Action objects for recommendation
         """
-        actions_id = [actions[i].action_id for i in range(len(actions))]
+        action_ids = [actions[i].action_id for i in range(len(actions))]
         self._actions.extend(actions)
-        self._actions_id.extend(actions_id)
 
         empirical_reward = self._modelstorage.get_model()['empirical_reward']
         action_times = self._modelstorage.get_model()['action_times']
         total_time = self._modelstorage.get_model()['total_time']
 
-        for action_id in self._actions_id:
+        for action_id in self.action_ids:
             empirical_reward[action_id] = 1.0
             action_times[action_id] = 1.0
 

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -90,7 +90,7 @@ class UCB1(BaseBandit):
             estimated_reward, uncertainty, score = six.next(self.ucb1_)
 
         action_recommend = []
-        actions_recommend_id = [self._actions_id[i] for i in np.array(score.values()).argsort()[-n_action:][::-1]]
+        actions_recommend_id = sorted(score, key=score.get, reverse=True)[:n_action]
         for action_id in actions_recommend_id:
             action_id = int(action_id)
             action = [action for action in self._actions if action.action_id == action_id][0]

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -18,8 +18,10 @@ class UCB1(BaseBandit):
     ----------
     actions : {array-like, None}
         Actions (arms) for recommendation
+
     historystorage: a :py:mod:'striatum.storage.HistoryStorage' object
         The object where we store the histories of contexts and rewards.
+
     modelstorage: a :py:mod:'straitum.storage.ModelStorage' object
         The object where we store the model parameters.
 
@@ -130,8 +132,8 @@ class UCB1(BaseBandit):
 
             Parameters
             ----------
-            actions : {array-like, None}
-                Actions (arms) for recommendation
+            actions : list
+                A list of Action objects for recommendation
         """
         actions_id = [actions[i].action_id for i in range(len(actions))]
         self._actions.extend(actions)

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -14,26 +14,26 @@ class UCB1(BaseBandit):
 
     """Upper Confidence Bound 1
 
-    Parameters
-    ----------
-    actions : {array-like, None}
-        Actions (arms) for recommendation
+        Parameters
+        ----------
+        actions : {array-like, None}
+            Actions (arms) for recommendation
 
-    historystorage: a :py:mod:'striatum.storage.HistoryStorage' object
-        The object where we store the histories of contexts and rewards.
+        historystorage: a :py:mod:'striatum.storage.HistoryStorage' object
+            The object where we store the histories of contexts and rewards.
 
-    modelstorage: a :py:mod:'straitum.storage.ModelStorage' object
-        The object where we store the model parameters.
+        modelstorage: a :py:mod:'straitum.storage.ModelStorage' object
+            The object where we store the model parameters.
 
-    Attributes
-    ----------
-    ucb1\_ : 'ucb1' object instance
-        The multi-armed bandit algorithm instances.
+        Attributes
+        ----------
+        ucb1\_ : 'ucb1' object instance
+            The multi-armed bandit algorithm instances.
 
-    References
-    ----------
-    .. [1]  Peter Auer, et al. "Finite-time Analysis of the Multiarmed Bandit Problem."
-            Machine Learning, 47. 2002.
+        References
+        ----------
+        .. [1]  Peter Auer, et al. "Finite-time Analysis of the Multiarmed Bandit Problem."
+                Machine Learning, 47. 2002.
     """
 
     def __init__(self, actions, historystorage, modelstorage):

--- a/striatum/simulation.py
+++ b/striatum/simulation.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-def data_simulation(times, d, actions):
+def data_simulation(times, d, actions, algorithm):
 
     """Simulate dataset for linucb and linthompsamp algorithms.
 
@@ -17,6 +17,9 @@ def data_simulation(times, d, actions):
         actions : list of Action objects
             List of actions to be chosen from.
 
+        algorithm: string
+            The bandit algorithm you want to use.
+
         Return
         ---------
         context: dictionary
@@ -25,14 +28,24 @@ def data_simulation(times, d, actions):
         desired_action:
             The action which will receive reward 1.
     """
+
     actions_id = [actions[i].action_id for i in range(len(actions))]
     context = {}
     desired_action = np.zeros((times, 1))
-    for t in range(times):
-        context[t] = {}
-        for i in actions_id:
-            context[t][i] = np.random.uniform(0, 1, d)
-        desired_action[t] = actions_id[np.argmax([np.sum(context[t][i]) for i in actions_id])]
+
+    if algorithm == 'Exp4P':
+        for t in range(times):
+            context[t] = np.random.uniform(0, 1, d)
+            for i in range(len(actions)):
+                if i * d / len(actions) < sum(context[t]) <= (i + 1) * d / len(actions):
+                    desired_action[t] = actions[i]
+
+    else:
+        for t in range(times):
+            context[t] = {}
+            for i in actions_id:
+                context[t][i] = np.random.uniform(0, 1, d)
+            desired_action[t] = actions_id[np.argmax([np.sum(context[t][i]) for i in actions_id])]
     return context, desired_action
 
 

--- a/striatum/simulation.py
+++ b/striatum/simulation.py
@@ -31,42 +31,8 @@ def data_simulation(times, d, actions):
     for t in range(times):
         context[t] = {}
         for i in actions_id:
-            context[t][i] = np.random.uniform(0, 1, (d, 1))
+            context[t][i] = np.random.uniform(0, 1, d)
         desired_action[t] = actions_id[np.argmax([np.sum(context[t][i]) for i in actions_id])]
-    return context, desired_action
-
-
-def data_simulation2(times, d, actions):
-
-    """Simulate dataset for exp4p.
-
-        Parameters
-        ----------
-        times: int
-            Total number of (context, reward) tuples you want to generate.
-
-        d: int
-            Dimension of the context.
-
-        actions : list of Action objects
-            List of actions to be chosen from.
-
-        Return
-        ---------
-        context: array-like
-            Contexts (d-by-1 array) at each iteration.
-
-        desired_action:
-            The action which will receive reward 1.
-    """
-
-    context = np.random.uniform(0, 1, (times, d))
-    desired_action = np.zeros(shape=(times, 1))
-    n_actions = len(actions)
-    for t in range(times):
-        for i in range(n_actions):
-            if i * d / n_actions < sum(context[t, :]) <= (i + 1) * d / n_actions:
-                desired_action[t] = actions[i]
     return context, desired_action
 
 

--- a/striatum/simulation.py
+++ b/striatum/simulation.py
@@ -2,7 +2,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 
-def data_simulation(times, d, actions, algorithm):
+def data_simulation(times, d, actions, algorithm=None):
 
     """Simulate dataset for linucb and linthompsamp algorithms.
 
@@ -38,7 +38,7 @@ def data_simulation(times, d, actions, algorithm):
             context[t] = np.random.uniform(0, 1, d)
             for i in range(len(actions)):
                 if i * d / len(actions) < sum(context[t]) <= (i + 1) * d / len(actions):
-                    desired_action[t] = actions[i]
+                    desired_action[t] = actions_id[i]
 
     else:
         for t in range(times):


### PR DESCRIPTION
Sorry for this super large PR. Since the basebandit changes, the circle CI cannot pass until all bandit algorithms are updated.

## Refactor bandit algorithms to allow multiple actions and rewards.
### `get_action(context, n_action)`:

(1) Parameters:
- `context`: For UCB1 and EXP3, `context` is `None`; for LinUCB and Thompson Sampling with linear payoff, `context` is a dictionary of the form `{action_id: context_vector}`. For EXP4P, `context` is a dictionary of the form `{expert_id: advice_vectors}`.
- `n_action`: int, number of actions your want the bandit to recommend.

(2) Return:
-  history_id: int, The history id of this query result.
- action_recommend : list of dictionaries. In each dictionary, it will contains {Action object, estimated_reward, uncertainty}.

### `reward(history_id, reward)`:

(1) Parameters:
- history_id : int, the history id of the action to reward.
- reward : dictionary of the form `{action_id: reward}`, where reward is a float

### `add_action(actions)`:
(1) Parameters:
- actions : list of `Action` objects for recommendation

## Refactor Exp4P

In the original algorithms, we require "models" (i.e. a list of scikit-learn supervised learning models) as one parameter for initialization. However, I think it is not quite flexible for users  since they may use models. The new version set `context` as a dictionary of expert advice experts, which is of the form `{expert_id: advice_vectors}`.

## Other Minor Changes

Due to the change of bandit algorithms, followings are also changes.

(1) Update the docstrings.
(2) Update all tests for bandit algorithms.
(3) Update all simulation files.
(4) Update the MovieLens examples.