### PR TITLE
fix python3 dictionary values special behavier

### DIFF
--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -70,7 +70,7 @@ class Exp3(BaseBandit):
 
         while True:
             w = self._modelstorage.get_model()['w']
-            w_sum = np.sum(w.values())
+            w_sum = np.sum(list(w.values()))
 
             query_vector = {}
             for action_id in self.action_ids:

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -81,7 +81,7 @@ class Exp4P(BaseBandit):
             if w == {}:
                 for i in advisors_id:
                     w[i] = 1
-            w_sum = np.sum(w.values())
+            w_sum = np.sum(list(w.values()))
 
             query_vector = [(1 - self.k * self.pmin) *
                             np.sum(np.array([w[i] * context[i][action_id] for i in advisors_id])/w_sum) +

--- a/striatum/bandit/linthompsamp.py
+++ b/striatum/bandit/linthompsamp.py
@@ -91,7 +91,7 @@ class LinThompSamp (BaseBandit):
         while True:
             context = yield
             action_ids = context.keys()
-            context_tmp = np.matrix(context.values())
+            context_tmp = np.matrix(list(context.values()))
             b = self._modelstorage.get_model()['B']
             muhat = self._modelstorage.get_model()['muhat']
             v = self.R * np.sqrt(24 / self.epsilon * self.d * np.log(1 / self.delta))


### PR DESCRIPTION
In python3:
```python
d = {'a': 1, 'b':2}
d.values() # dict_values([1, 2])

np.sum(d.values) # dict_values([1, 2]) not 3
```
