### PR TITLE
Action storage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+six
 numpy
 scipy
 scikit-learn

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ cover-package=striatum
 debug=nose.loader
 cover-html=1
 cover-html-dir=coverage
+nocapture=1
 
 [bdist_wheel]
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ else:
     setup_requires = [
         'nose',
         'coverage',
-        'scikit-learn',
     ]
     install_requires = [
         'six',

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description='Contextual bandit in python',
     author='Y.-Y. Yang, Y.-A. Lin',
     author_email='b01902066@csie.ntu.edu.tw, r02922163@csie.ntu.edu.tw',
-    url='https://github.com/ntucllab/straitum',
+    url='https://github.com/ntucllab/striatum',
     setup_requires=setup_requires,
     install_requires=install_requires,
     classifiers=[

--- a/simulation/simulation_exp3.py
+++ b/simulation/simulation_exp3.py
@@ -1,29 +1,31 @@
 import matplotlib.pyplot as plt
-
-from striatum.storage import history
-from striatum.storage import model
-from striatum.bandit import Exp3
-from striatum.bandit.bandit import Action
-from striatum import simulation
 import numpy as np
+
+from striatum.storage import (
+    MemoryHistoryStorage,
+    MemoryModelStorage,
+    MemoryActionStorage,
+    Action,
+)
+from striatum.bandit import Exp3
+from striatum import simulation
 
 
 def main():
     n_rounds = 1000
     context_dimension = 5
-    actions = [Action(action_id) for action_id in range(1, 6)]
+    action_storage = MemoryActionStorage()
+    action_storage.add([Action(i) for i in range(5)])
     random_state = np.random.RandomState(0)
 
     # Parameter tuning
     tuning_region = np.arange(0.001, 1, 0.03)
     ctr_tuning = np.zeros(shape=len(tuning_region))
     context1, desired_actions1 = simulation.simulate_data(
-        n_rounds, context_dimension, actions, random_state=random_state)
+        n_rounds, context_dimension, action_storage, random_state=random_state)
     for gamma_i, gamma in enumerate(tuning_region):
-        historystorage = history.MemoryHistoryStorage()
-        modelstorage = model.MemoryModelStorage()
-        policy = Exp3(actions, historystorage, modelstorage, gamma,
-                      random_state=random_state)
+        policy = Exp3(MemoryHistoryStorage(), MemoryModelStorage(),
+                      action_storage, gamma, random_state=random_state)
         cum_regret = simulation.evaluate_policy(policy, context1,
                                                 desired_actions1)
         ctr_tuning[gamma_i] = n_rounds - cum_regret[-1]
@@ -35,15 +37,13 @@ def main():
     # Regret Analysis
     n_rounds = 10000
     context2, desired_actions2 = simulation.simulate_data(
-        n_rounds, context_dimension, actions, random_state=random_state)
-    historystorage = history.MemoryHistoryStorage()
-    modelstorage = model.MemoryModelStorage()
-    policy = Exp3(actions, historystorage, modelstorage, gamma=gamma_opt,
-                  random_state=random_state)
+        n_rounds, context_dimension, action_storage, random_state=random_state)
+    policy = Exp3(MemoryHistoryStorage(), MemoryModelStorage(),
+                  action_storage, gamma=gamma_opt, random_state=random_state)
 
     for t in range(n_rounds):
         history_id, action = policy.get_action(context2[t], 1)
-        action_id = action[0]['action'].action_id
+        action_id = action[0]['action'].id
         if desired_actions2[t] != action_id:
             policy.reward(history_id, {action_id: 0})
         else:

--- a/simulation/simulation_linucb.py
+++ b/simulation/simulation_linucb.py
@@ -3,25 +3,32 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from striatum import simulation
-from striatum.storage import MemoryHistoryStorage, MemoryModelStorage
+from striatum.storage import (
+    MemoryHistoryStorage,
+    MemoryModelStorage,
+    MemoryActionStorage,
+    Action,
+)
 from striatum.bandit import LinUCB
-from striatum.bandit.bandit import Action
 
 
 def main():
     n_rounds = 1000
     context_dimension = 5
-    actions = [Action(i) for i in range(5)]
+    action_storage = MemoryActionStorage()
+    for i in range(5):
+        action_storage.add(Action(i + 1))
 
     # Parameter tuning
     tuning_region = np.arange(0, 3, 0.05)
     ctr_tuning = np.empty(shape=len(tuning_region))
     context1, desired_actions1 = simulation.simulate_data(
-        n_rounds, context_dimension, actions, random_state=0)
+        n_rounds, context_dimension, action_storage, random_state=0)
+    import ipdb; ipdb.set_trace()
     for alpha_i, alpha in enumerate(tuning_region):
         policy = LinUCB(actions,
-                        historystorage=MemoryHistoryStorage(),
-                        modelstorage=MemoryModelStorage(),
+                        history_storage=MemoryHistoryStorage(),
+                        model_storage=MemoryModelStorage(),
                         alpha=alpha, context_dimension=context_dimension)
         cum_regret = simulation.evaluate_policy(policy, context1,
                                                 desired_actions1)
@@ -36,8 +43,8 @@ def main():
     context2, desired_actions2 = simulation.simulate_data(
         n_rounds, context_dimension, actions, random_state=1)
     policy = LinUCB(actions,
-                    historystorage=MemoryHistoryStorage(),
-                    modelstorage=MemoryModelStorage(),
+                    history_storage=MemoryHistoryStorage(),
+                    model_storage=MemoryModelStorage(),
                     alpha=alpha_opt, context_dimension=context_dimension)
 
     for t in range(n_rounds):

--- a/simulation/simulation_linucb.py
+++ b/simulation/simulation_linucb.py
@@ -16,19 +16,17 @@ def main():
     n_rounds = 1000
     context_dimension = 5
     action_storage = MemoryActionStorage()
-    for i in range(5):
-        action_storage.add(Action(i + 1))
+    action_storage.add([Action(i) for i in range(5)])
 
     # Parameter tuning
     tuning_region = np.arange(0, 3, 0.05)
     ctr_tuning = np.empty(shape=len(tuning_region))
     context1, desired_actions1 = simulation.simulate_data(
         n_rounds, context_dimension, action_storage, random_state=0)
-    import ipdb; ipdb.set_trace()
     for alpha_i, alpha in enumerate(tuning_region):
-        policy = LinUCB(actions,
-                        history_storage=MemoryHistoryStorage(),
+        policy = LinUCB(history_storage=MemoryHistoryStorage(),
                         model_storage=MemoryModelStorage(),
+                        action_storage=action_storage,
                         alpha=alpha, context_dimension=context_dimension)
         cum_regret = simulation.evaluate_policy(policy, context1,
                                                 desired_actions1)
@@ -41,10 +39,10 @@ def main():
     # Regret Analysis
     n_rounds = 10000
     context2, desired_actions2 = simulation.simulate_data(
-        n_rounds, context_dimension, actions, random_state=1)
-    policy = LinUCB(actions,
-                    history_storage=MemoryHistoryStorage(),
+        n_rounds, context_dimension, action_storage, random_state=1)
+    policy = LinUCB(history_storage=MemoryHistoryStorage(),
                     model_storage=MemoryModelStorage(),
+                    action_storage=action_storage,
                     alpha=alpha_opt, context_dimension=context_dimension)
 
     for t in range(n_rounds):

--- a/simulation/simulation_linucb.py
+++ b/simulation/simulation_linucb.py
@@ -47,7 +47,7 @@ def main():
 
     for t in range(n_rounds):
         history_id, action = policy.get_action(context2[t], 1)
-        action_id = action[0]['action'].action_id
+        action_id = action[0]['action'].id
         if desired_actions2[t] != action_id:
             policy.reward(history_id, {action_id: 0})
         else:

--- a/simulation/simulation_ucb1.py
+++ b/simulation/simulation_ucb1.py
@@ -1,27 +1,31 @@
 from six.moves import range
 import matplotlib.pyplot as plt
 
-from striatum.storage import MemoryHistoryStorage, MemoryModelStorage
-from striatum.bandit import ucb1
+from striatum.storage import (
+    MemoryHistoryStorage,
+    MemoryModelStorage,
+    MemoryActionStorage,
+    Action,
+)
+from striatum.bandit import UCB1
 from striatum import simulation
-from striatum.bandit.bandit import Action
 
 
 def main():
     context_dimension = 5
-    actions = [Action(action_id) for action_id in range(1, 6)]
+    action_storage = MemoryActionStorage()
+    action_storage.add([Action(i) for i in range(5)])
 
     # Regret Analysis
     n_rounds = 40000
     context, desired_actions = simulation.simulate_data(
-        n_rounds, context_dimension, actions, random_state=0)
-    historystorage = MemoryHistoryStorage()
-    modelstorage = MemoryModelStorage()
-    policy = ucb1.UCB1(actions, historystorage, modelstorage)
+        n_rounds, context_dimension, action_storage, random_state=0)
+    policy = UCB1(MemoryHistoryStorage(), MemoryModelStorage(),
+                  action_storage)
 
     for t in range(n_rounds):
         history_id, action = policy.get_action(context[t], 1)
-        action_id = action[0]['action'].action_id
+        action_id = action[0]['action'].id
         if desired_actions[t] != action_id:
             policy.reward(history_id, {action_id: 0})
         else:

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -41,7 +41,7 @@ class BaseBandit(object):
         self._action_storage = action_storage
 
     @abstractmethod
-    def get_action(self, context, n_actions=1):
+    def get_action(self, context, n_actions=None):
         """Return the action to perform
 
         Parameters
@@ -49,8 +49,9 @@ class BaseBandit(object):
         context : dictionary
             Contexts {action_id: context} of different actions.
 
-        n_actions: int
-            Number of actions wanted to recommend users.
+        n_actions: int (default: None)
+            Number of actions wanted to recommend users. If None, only return
+            one action.
 
         Returns
         -------

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -1,23 +1,9 @@
 """
 Bandit interfaces
 """
-
 from abc import abstractmethod
 
 from striatum import rewardplot as rplt
-
-
-class Action(object):
-    r"""The action object
-
-    Parameters
-    ----------
-    action_id: int
-        The index of this action.
-    """
-
-    def __init__(self, action_id):
-        self.action_id = action_id
 
 
 class BaseBandit(object):
@@ -25,54 +11,34 @@ class BaseBandit(object):
 
     Parameters
     ----------
-    historystorage : historystorage object
-        The historystorage object to store history context, actions and rewards.
+    history_storage : HistoryStorage object
+        The HistoryStorage object to store history context, actions and rewards.
 
-    modelstorage : modelstorage object
-        The modelstorage object to store model parameters.
+    model_storage : ModelStorage object
+        The ModelStorage object to store model parameters.
 
-    actions : list of Action objects
-        List of actions to be chosen from.
+    action_storage : ActionStorage object
+        The ActionStorage object to store actions.
 
     Attributes
     ----------
-    \_historystorage : historystorage object
-        The historystorage object to store history context, actions and rewards.
+    \_history_storage : HistoryStorage object
+        The HistoryStorage object to store history context, actions and rewards.
 
-    \_modelstorage : modelstorage object
-        The modelstorage object to store model parameters.
+    \_model_storage : ModelStorage object
+        The ModelStorage object to store model parameters.
 
-    \_actions : list of Action objects
-        List of actions to be chosen from.
+    \_action_storage : ActionStorage object
+        The ActionStorage object to store actions.
 
     \_action_ids: list of integers
         List of all action_id's.
     """
 
-    def __init__(self, historystorage, modelstorage, actions):
-        self._historystorage = historystorage
-        self._modelstorage = modelstorage
-        self._actions = actions
-
-    @property
-    def historystorage(self):
-        """HistoryStorage object that stores history"""
-        return self._historystorage
-
-    @property
-    def modelstorage(self):
-        """ModelStorage object that stores model parameters"""
-        return self._modelstorage
-
-    @property
-    def actions(self):
-        """List of actions"""
-        return self._actions
-
-    @property
-    def action_ids(self):
-        """List of action ids"""
-        return [self._actions[i].action_id for i in range(len(self._actions))]
+    def __init__(self, history_storage, model_storage, action_storage):
+        self._history_storage = history_storage
+        self._model_storage = model_storage
+        self._action_storage = action_storage
 
     @abstractmethod
     def get_action(self, context, n_actions=1):
@@ -141,10 +107,3 @@ class BaseBandit(object):
         """Plot average regret with respect to time.
         """
         rplt.plot_avg_regret(self)
-
-    def get_action_with_id(self, action_id):
-        for action in self._actions:
-            if action.action_id == action_id:
-                return action
-        else:
-            raise KeyError("action_id {} not found".format(action_id))

--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -40,6 +40,10 @@ class BaseBandit(object):
         self._model_storage = model_storage
         self._action_storage = action_storage
 
+    @property
+    def history_storage(self):
+        return self._history_storage
+
     @abstractmethod
     def get_action(self, context, n_actions=None):
         """Return the action to perform

--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -181,12 +181,14 @@ class Exp3(BaseBandit):
         actions : iterable
             A list of Action objects for recommendation
         """
-        action_ids = [actions[i].action_id for i in range(len(actions))]
-        w = self._model_storage.get_model()['w']
-        query_vector = self._model_storage.get_model()['query_vector']
+        self._action_storage.add(actions)
 
-        for action_id in action_ids:
-            query_vector[action_id] = 0
-            w[action_id] = 1.0  # weight vector
+        model = self._model_storage.get_model()
+        w = model['w']
+        query_vector = model['query_vector']
 
-        self._actions.extend(actions)
+        for action in actions:
+            query_vector[action.id] = 0
+            w[action.id] = 1.0  # weight vector
+
+        self._model_storage.save_model(model)

--- a/striatum/bandit/exp4p.py
+++ b/striatum/bandit/exp4p.py
@@ -199,14 +199,3 @@ class Exp4P(BaseBandit):
 
         # Update the history
         self._historystorage.add_reward(history_id, rewards)
-
-    def add_action(self, actions):
-        """ Add new actions (if needed).
-
-        Parameters
-        ----------
-        actions : iterable
-            A list of Action objects for recommendation
-        """
-
-        self._actions.extend(actions)

--- a/striatum/bandit/linucb.py
+++ b/striatum/bandit/linucb.py
@@ -69,7 +69,7 @@ class LinUCB(BaseBandit):
             # linear model b = dot(xt, theta)
             'theta': {},
         }
-        for action_id in self.action_ids:
+        for action_id in self._action_storage.iterids():
             self._init_action_model(model, action_id)
 
         self._model_storage.save_model(model)
@@ -91,7 +91,7 @@ class LinUCB(BaseBandit):
         estimated_reward = {}
         uncertainty = {}
         score = {}
-        for action_id in self.action_ids:
+        for action_id in self._action_storage.iterids():
             action_context = np.reshape(context[action_id], (-1, 1))
             estimated_reward[action_id] = float(
                 theta[action_id].T.dot(action_context))
@@ -133,7 +133,7 @@ class LinUCB(BaseBandit):
                                            reverse=True)[:n_actions]
 
         for action_id in action_recommendation_ids:
-            action = self.get_action_with_id(action_id)
+            action = self._action_storage.get(action_id)
             action_recommendation.append({
                 'action': action,
                 'estimated_reward': estimated_reward[action_id],
@@ -191,10 +191,10 @@ class LinUCB(BaseBandit):
         actions : iterable
             A list of Action objects for recommendation
         """
-        self._actions.extend(actions)
+        new_action_ids = self._action_storage.add(actions)
         model = self._model_storage.get_model()
 
-        for action in actions:
-            self._init_action_model(model, action.action_id)
+        for action_id in new_action_ids:
+            self._init_action_model(model, action_id)
 
         self._model_storage.save_model(model)

--- a/striatum/bandit/tests/base_bandit_test.py
+++ b/striatum/bandit/tests/base_bandit_test.py
@@ -24,7 +24,6 @@ class BaseBanditTest(object):
         self.assertEqual(self.history_storage, policy._history_storage)
         self.assertEqual(self.history_storage, policy.history_storage)
         self.assertEqual(self.action_storage, policy._action_storage)
-        self.assertEqual(self.context_dimension, policy.context_dimension)
 
     def test_get_first_action(self):
         policy = self.policy

--- a/striatum/bandit/tests/base_bandit_test.py
+++ b/striatum/bandit/tests/base_bandit_test.py
@@ -15,7 +15,8 @@ class BaseBanditTest(object):
         self.model_storage = MemoryModelStorage()
         self.history_storage = MemoryHistoryStorage()
         self.action_storage = MemoryActionStorage()
-        self.action_storage.add([Action(i + 1) for i in range(3)])
+        self.actions = [Action(i + 1) for i in range(3)]
+        self.action_storage.add(self.actions)
 
     def test_initialization(self):
         policy = self.policy
@@ -94,3 +95,10 @@ class BaseBanditTest(object):
             policy._history_storage.get_unrewarded_history(history_id1).reward)
         self.assertDictEqual(
             policy._history_storage.get_history(history_id2).reward, {3: 1})
+
+    def test_add_action_change_storage(self):
+        policy = self.policy
+        new_actions = [Action() for i in range(2)]
+        policy.add_action(new_actions)
+        self.assertEqual(set(a.id for a in self.actions + new_actions),
+                         set(self.action_storage.iterids()))

--- a/striatum/bandit/tests/base_bandit_test.py
+++ b/striatum/bandit/tests/base_bandit_test.py
@@ -1,0 +1,95 @@
+"""Unit test for LinUCB
+"""
+import numpy as np
+
+from striatum.storage import (
+    MemoryHistoryStorage,
+    MemoryModelStorage,
+    MemoryActionStorage,
+    Action,
+)
+
+
+class BaseBanditTest(object):
+    #pylint: disable=protected-access
+
+    def setUp(self):  # pylint: disable=invalid-name
+        self.model_storage = MemoryModelStorage()
+        self.history_storage = MemoryHistoryStorage()
+        self.action_storage = MemoryActionStorage()
+        self.action_storage.add([Action(i + 1) for i in range(3)])
+
+    def test_initialization(self):
+        policy = self.policy
+        self.assertEqual(self.model_storage, policy._model_storage)
+        self.assertEqual(self.history_storage, policy._history_storage)
+        self.assertEqual(self.history_storage, policy.history_storage)
+        self.assertEqual(self.action_storage, policy._action_storage)
+        self.assertEqual(self.context_dimension, policy.context_dimension)
+
+    def test_get_first_action(self):
+        policy = self.policy
+        context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        history_id, action = policy.get_action(context, 1)
+        self.assertEqual(history_id, 0)
+        self.assertIn(action[0]['action'].id, self.action_storage.iterids())
+        self.assertEqual(
+            policy._history_storage.get_unrewarded_history(history_id).context,
+            context)
+
+    def test_update_reward(self):
+        policy = self.policy
+        context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        history_id, _ = policy.get_action(context, 1)
+        policy.reward(history_id, {3: 1})
+        self.assertEqual(
+            policy._history_storage.get_history(history_id).reward,
+            {3: 1})
+
+    def test_delay_reward(self):
+        policy = self.policy
+        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        context2 = {1: [0, 0], 2: [3, 3], 3: [6, 6]}
+        history_id1, _ = policy.get_action(context1, 2)
+        history_id2, _ = policy.get_action(context2, 1)
+        policy.reward(history_id1, {2: 1, 3: 1})
+        self.assertEqual(
+            policy._history_storage.get_history(history_id1).context, context1)
+        self.assertEqual(
+            policy._history_storage.get_unrewarded_history(history_id2).context, context2)
+        self.assertEqual(
+            policy._history_storage.get_history(history_id1).reward,
+            {2: 1, 3: 1})
+        self.assertEqual(
+            policy._history_storage.get_unrewarded_history(history_id2).reward, None)
+
+    def test_reward_order_descending(self):
+        policy = self.policy
+        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        context2 = {1: [0, 0], 2: [3, 3], 3: [6, 6]}
+        history_id1, _ = policy.get_action(context1, 2)
+        history_id2, _ = policy.get_action(context2, 1)
+        policy.reward(history_id2, {3: 1})
+        self.assertEqual(
+            policy._history_storage.get_unrewarded_history(history_id1).context, context1)
+        self.assertEqual(
+            policy._history_storage.get_history(history_id2).context, context2)
+        self.assertEqual(
+            policy._history_storage.get_unrewarded_history(history_id1).reward, None)
+        self.assertEqual(
+            policy._history_storage.get_history(history_id2).reward, {3: 1})
+
+    def test_add_action(self):
+        policy = self.policy
+        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        history_id, _ = policy.get_action(context1, 2)
+        a4 = Action(4)
+        a5 = Action(5)
+        policy.add_action([a4, a5])
+        policy.reward(history_id, {3: 1})
+        self.assertTrue((policy._model_storage.get_model()['A'][4] == np.identity(2)).all())
+
+        context2 = {1: [1, 1], 2: [2, 2], 3: [3, 3], 4: [4, 4], 5: [5, 5]}
+        history_id2, _ = policy.get_action(context2, 1)
+        policy.reward(history_id2, {4: 4, 5: 5})
+        self.assertFalse((policy._model_storage.get_model()['A'][4] == np.identity(2)).all())

--- a/striatum/bandit/tests/base_bandit_test.py
+++ b/striatum/bandit/tests/base_bandit_test.py
@@ -96,6 +96,9 @@ class BaseBanditTest(object):
         self.assertDictEqual(
             policy._history_storage.get_history(history_id2).reward, {3: 1})
 
+
+class ChangeableActionSetBanditTest(object):
+
     def test_add_action_change_storage(self):
         policy = self.policy
         new_actions = [Action() for i in range(2)]

--- a/striatum/bandit/tests/test_exp4p.py
+++ b/striatum/bandit/tests/test_exp4p.py
@@ -1,105 +1,101 @@
-import numpy as np
-import unittest
-from sklearn.naive_bayes import MultinomialNB
-from sklearn.linear_model import LogisticRegression
-from sklearn.multiclass import OneVsRestClassifier
-import sys
-sys.path.append("..")
-from striatum.storage import history as history
-from striatum.storage import model as model
-from striatum.bandit import exp4p
-from striatum.bandit.bandit import Action
+# import numpy as np
+# import unittest
+# from sklearn.naive_bayes import MultinomialNB
+# from sklearn.linear_model import LogisticRegression
+# from sklearn.multiclass import OneVsRestClassifier
+# import sys
+# sys.path.append("..")
+# from striatum.storage import history as history
+# from striatum.storage import model as model
+# from striatum.bandit import exp4p
+# from striatum.bandit.bandit import Action
 
 
-class Exp4P(unittest.TestCase):
-    def setUp(self):
-        self.modelstorage = model.MemoryModelStorage()
-        self.historystorage = history.MemoryHistoryStorage()
-        a1 = Action(1)
-        a2 = Action(2)
-        a3 = Action(3)
-        a4 = Action(4)
-        a5 = Action(5)
-        self.actions = [a1, a2, a3, a4, a5]
-        self.action_ids = [1, 2, 3, 4, 5]
+# class Exp4P(unittest.TestCase):
+#     def setUp(self):
+#         self.modelstorage = model.MemoryModelStorage()
+#         self.historystorage = history.MemoryHistoryStorage()
+#         a1 = Action(1)
+#         a2 = Action(2)
+#         a3 = Action(3)
+#         a4 = Action(4)
+#         a5 = Action(5)
+#         self.actions = [a1, a2, a3, a4, a5]
+#         self.action_ids = [1, 2, 3, 4, 5]
 
-    def test_initialization(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
-        self.assertEqual(self.actions, policy._actions)
-        self.assertEqual(0.1, policy.delta)
+#     def test_initialization(self):
+#         policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
+#         self.assertEqual(self.actions, policy._actions)
+#         self.assertEqual(0.1, policy.delta)
 
-    def test_get_first_action(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
-        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
-        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
-        context = {1: prob1, 2: prob2}
-        history_id, action = policy.get_action(context, 1)
-        self.assertEqual(history_id, 0)
-        self.assertIn(action[0]['action'], self.actions)
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id).context, context)
+#     def test_get_first_action(self):
+#         policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
+#         prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+#         prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+#         context = {1: prob1, 2: prob2}
+#         history_id, action = policy.get_action(context, 1)
+#         self.assertEqual(history_id, 0)
+#         self.assertIn(action[0]['action'], self.actions)
+#         self.assertEqual(policy._historystorage.get_unrewarded_history(history_id).context, context)
 
-    def test_update_reward(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
-        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
-        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
-        context = {1: prob1, 2: prob2}
-        history_id, action = policy.get_action(context, 1)
-        policy.reward(history_id, {1: 1.0})
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 1.0})
+#     def test_update_reward(self):
+#         policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
+#         prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+#         prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+#         context = {1: prob1, 2: prob2}
+#         history_id, action = policy.get_action(context, 1)
+#         policy.reward(history_id, {1: 1.0})
+#         self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 1.0})
 
-    def test_model_storage(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
-        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
-        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
-        context = {1: prob1, 2: prob2}
-        history_id, action = policy.get_action(context, 1)
-        policy.reward(history_id, {1: 1.0})
-        self.assertEqual(len(policy._modelstorage._model['w']), 2)
-        self.assertEqual(len(policy._modelstorage._model['action_probs']), 5)
+#     def test_model_storage(self):
+#         policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
+#         prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+#         prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+#         context = {1: prob1, 2: prob2}
+#         history_id, action = policy.get_action(context, 1)
+#         policy.reward(history_id, {1: 1.0})
+#         self.assertEqual(len(policy._modelstorage._model['w']), 2)
+#         self.assertEqual(len(policy._modelstorage._model['action_probs']), 5)
 
-    def test_delay_reward(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
-        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
-        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
-        context1 = {1: prob1, 2: prob2}
-        history_id1, action1 = policy.get_action(context1, 1)
-        prob1 = {1: 0.32, 2: 0.51, 3: 0.05, 4: 0.06, 5: 0.06}
-        prob2 = {1: 0.32, 2: 0.42, 3: 0.12, 4: 0.07, 5: 0.07}
-        context2 = {1: prob1, 2: prob2}
-        history_id2, action2 = policy.get_action(context2, 2)
-        policy.reward(history_id1, {1: 1.0})
-        self.assertEqual(policy._historystorage.get_history(history_id1).context, context1)
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id2).context, context2)
-        self.assertEqual(policy._historystorage.get_history(history_id1).reward, {1: 1.0})
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id2).reward, None)
+#     def test_delay_reward(self):
+#         policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
+#         prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+#         prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+#         context1 = {1: prob1, 2: prob2}
+#         history_id1, action1 = policy.get_action(context1, 1)
+#         prob1 = {1: 0.32, 2: 0.51, 3: 0.05, 4: 0.06, 5: 0.06}
+#         prob2 = {1: 0.32, 2: 0.42, 3: 0.12, 4: 0.07, 5: 0.07}
+#         context2 = {1: prob1, 2: prob2}
+#         history_id2, action2 = policy.get_action(context2, 2)
+#         policy.reward(history_id1, {1: 1.0})
+#         self.assertEqual(policy._historystorage.get_history(history_id1).context, context1)
+#         self.assertEqual(policy._historystorage.get_unrewarded_history(history_id2).context, context2)
+#         self.assertEqual(policy._historystorage.get_history(history_id1).reward, {1: 1.0})
+#         self.assertEqual(policy._historystorage.get_unrewarded_history(history_id2).reward, None)
 
-    def test_reward_order_descending(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
-        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
-        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
-        context1 = {1: prob1, 2: prob2}
-        history_id1, action1 = policy.get_action(context1, 1)
-        prob1 = {1: 0.32, 2: 0.51, 3: 0.05, 4: 0.06, 5: 0.06}
-        prob2 = {1: 0.32, 2: 0.42, 3: 0.12, 4: 0.07, 5: 0.07}
-        context2 = {1: prob1, 2: prob2}
-        history_id2, action2 = policy.get_action(context2, 2)
-        policy.reward(history_id2, {1: 1.0, 2: 1.0})
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id1).reward, None)
-        self.assertEqual(policy._historystorage.get_history(history_id2).reward, {1: 1.0, 2: 1.0})
+#     def test_reward_order_descending(self):
+#         policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
+#         prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+#         prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+#         context1 = {1: prob1, 2: prob2}
+#         history_id1, action1 = policy.get_action(context1, 1)
+#         prob1 = {1: 0.32, 2: 0.51, 3: 0.05, 4: 0.06, 5: 0.06}
+#         prob2 = {1: 0.32, 2: 0.42, 3: 0.12, 4: 0.07, 5: 0.07}
+#         context2 = {1: prob1, 2: prob2}
+#         history_id2, action2 = policy.get_action(context2, 2)
+#         policy.reward(history_id2, {1: 1.0, 2: 1.0})
+#         self.assertEqual(policy._historystorage.get_unrewarded_history(history_id1).reward, None)
+#         self.assertEqual(policy._historystorage.get_history(history_id2).reward, {1: 1.0, 2: 1.0})
 
-    def test_add_action(self):
-        policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
-        prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
-        prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
-        context = {1: prob1, 2: prob2}
-        history_id, action = policy.get_action(context, 2)
-        a6 = Action(6)
-        a7 = Action(7)
-        policy.add_action([a6, a7])
-        policy.reward(history_id, {3: 1})
-        self.assertEqual(len(policy._actions), 7)
-        self.assertEqual(policy.action_ids, [1, 2, 3, 4, 5, 6, 7])
-
-
-if __name__ == '__main__':
-    unittest.main()
+#     def test_add_action(self):
+#         policy = exp4p.Exp4P(self.actions, self.historystorage, self.modelstorage, delta=0.1, p_min=None)
+#         prob1 = {1: 0.82, 2: 0.03, 3: 0.05, 4: 0.04, 5: 0.06}
+#         prob2 = {1: 0.72, 2: 0.07, 3: 0.07, 4: 0.07, 5: 0.07}
+#         context = {1: prob1, 2: prob2}
+#         history_id, action = policy.get_action(context, 2)
+#         a6 = Action(6)
+#         a7 = Action(7)
+#         policy.add_action([a6, a7])
+#         policy.reward(history_id, {3: 1})
+#         self.assertEqual(len(policy._actions), 7)
+#         self.assertEqual(policy.action_ids, [1, 2, 3, 4, 5, 6, 7])

--- a/striatum/bandit/tests/test_linthompsamp.py
+++ b/striatum/bandit/tests/test_linthompsamp.py
@@ -2,10 +2,12 @@ import unittest
 
 from striatum.bandit import LinThompSamp
 from striatum.storage import Action
-from .base_bandit_test import BaseBanditTest
+from .base_bandit_test import BaseBanditTest, ChangeableActionSetBanditTest
 
 
-class TestLinThompSamp(BaseBanditTest, unittest.TestCase):
+class TestLinThompSamp(ChangeableActionSetBanditTest,
+                       BaseBanditTest,
+                       unittest.TestCase):
     #pylint: disable=protected-access
 
     def setUp(self):

--- a/striatum/bandit/tests/test_linthompsamp.py
+++ b/striatum/bandit/tests/test_linthompsamp.py
@@ -8,7 +8,7 @@ from .base_bandit_test import BaseBanditTest, ChangeableActionSetBanditTest
 class TestLinThompSamp(ChangeableActionSetBanditTest,
                        BaseBanditTest,
                        unittest.TestCase):
-    #pylint: disable=protected-access
+    # pylint: disable=protected-access
 
     def setUp(self):
         super(TestLinThompSamp, self).setUp()
@@ -23,8 +23,10 @@ class TestLinThompSamp(ChangeableActionSetBanditTest,
 
     def test_initialization(self):
         super(TestLinThompSamp, self).test_initialization()
-        self.assertEqual(self.R, self.policy.R)
-        self.assertEqual(self.epsilon, self.policy.epsilon)
+        policy = self.policy
+        self.assertEqual(self.context_dimension, policy.context_dimension)
+        self.assertEqual(self.R, policy.R)
+        self.assertEqual(self.epsilon, policy.epsilon)
 
     def test_model_storage(self):
         policy = self.policy
@@ -43,6 +45,8 @@ class TestLinThompSamp(ChangeableActionSetBanditTest,
         history_id, _ = policy.get_action(context1, 2)
         new_actions = [Action() for i in range(2)]
         policy.add_action(new_actions)
+        self.assertEqual(len(new_actions) + len(self.actions),
+                         policy._action_storage.count())
         policy.reward(history_id, {3: 1})
 
         context2 = {1: [1, 1], 2: [2, 2], 3: [3, 3], 4: [4, 4], 5: [5, 5]}

--- a/striatum/bandit/tests/test_linthompsamp.py
+++ b/striatum/bandit/tests/test_linthompsamp.py
@@ -1,97 +1,49 @@
 import unittest
-import sys
-sys.path.append("..")
-from striatum.storage import history as history
-from striatum.storage import model as model
-from striatum.bandit import linthompsamp
-from striatum.bandit.bandit import Action
 
-class TestLinThompSamp(unittest.TestCase):
+from striatum.bandit import LinThompSamp
+from striatum.storage import Action
+from .base_bandit_test import BaseBanditTest
+
+
+class TestLinThompSamp(BaseBanditTest, unittest.TestCase):
+    #pylint: disable=protected-access
+
     def setUp(self):
-        self.modelstorage = model.MemoryModelStorage()
-        self.historystorage = history.MemoryHistoryStorage()
-        a1 = Action(1)
-        a2 = Action(2)
-        a3 = Action(3)
-        self.actions = [a1, a2, a3]
+        super(TestLinThompSamp, self).setUp()
         self.context_dimension = 2
         self.delta = 0.5
-        self.R = 0.5
+        self.R = 0.5  # pylint: disable=invalid-name
         self.epsilon = 0.1
+        self.policy = LinThompSamp(
+            self.history_storage, self.model_storage,
+            self.action_storage, self.context_dimension,
+            self.delta, self.R, self.epsilon)
 
     def test_initialization(self):
-        policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
-                                           self.modelstorage, self.context_dimension, self.delta, self.R, self.epsilon)
-        self.assertEqual(self.actions, policy._actions)
-        self.assertEqual(self.context_dimension, policy.context_dimension)
-        self.assertEqual(self.R, policy.R)
-        self.assertEqual(self.epsilon, policy.epsilon)
-
-    def test_get_first_action(self):
-        policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
-                                           self.modelstorage, self.context_dimension, self.delta, self.R, self.epsilon)
-        context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, action = policy.get_action(context, 1)
-        self.assertEqual(history_id, 0)
-        self.assertIn(action[0]['action'], self.actions)
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id).context, context)
-
-    def test_update_reward(self):
-        policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
-                                           self.modelstorage, self.context_dimension, self.delta, self.R, self.epsilon)
-        context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, action = policy.get_action(context, 1)
-        policy.reward(history_id, {3: 1})
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, {3: 1})
+        super(TestLinThompSamp, self).test_initialization()
+        self.assertEqual(self.R, self.policy.R)
+        self.assertEqual(self.epsilon, self.policy.epsilon)
 
     def test_model_storage(self):
-        policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
-                                           self.modelstorage, self.context_dimension, self.delta, self.R, self.epsilon)
+        policy = self.policy
+        model = self.policy._model_storage.get_model()
         context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, action = policy.get_action(context, 2)
+        history_id, _ = policy.get_action(context, 2)
         policy.reward(history_id, {2: 1, 3: 1})
-        self.assertTrue((policy._modelstorage._model['B'].shape == (2, 2)) == True)
-        self.assertEqual(len(policy._modelstorage._model['mu_hat']), 2)
-        self.assertEqual(len(policy._modelstorage._model['f']), 2)
-
-    def test_delay_reward(self):
-        policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
-                                           self.modelstorage, self.context_dimension, self.delta, self.R, self.epsilon)
-        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        context2 = {1: [0, 0], 2: [3, 3], 3: [6, 6]}
-        history_id1, action1 = policy.get_action(context1, 2)
-        history_id2, action2 = policy.get_action(context2, 1)
-        policy.reward(history_id1, {2: 1, 3: 1})
-        self.assertEqual(policy._historystorage.get_history(history_id1).context, context1)
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id2).context, context2)
-        self.assertEqual(policy._historystorage.get_history(history_id1).reward, {2: 1, 3: 1})
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id2).reward, None)
-
-    def test_reward_order_descending(self):
-        policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
-                                           self.modelstorage, self.context_dimension, self.delta, self.R, self.epsilon)
-        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        context2 = {1: [0, 0], 2: [3, 3], 3: [6, 6]}
-        history_id1, action1 = policy.get_action(context1, 2)
-        history_id2, action2 = policy.get_action(context2, 1)
-        policy.reward(history_id2, {3: 1})
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id1).context, context1)
-        self.assertEqual(policy._historystorage.get_history(history_id2).context, context2)
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id1).reward, None)
-        self.assertEqual(policy._historystorage.get_history(history_id2).reward, {3: 1})
+        self.assertTupleEqual(model['B'].shape, (self.context_dimension,
+                                                 self.context_dimension))
+        self.assertEqual(len(model['mu_hat']), self.context_dimension)
+        self.assertEqual(len(model['f']), self.context_dimension)
 
     def test_add_action(self):
-        policy = linthompsamp.LinThompSamp(self.actions, self.historystorage,
-                                           self.modelstorage, self.context_dimension, self.delta, self.R, self.epsilon)
+        policy = self.policy
         context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, action = policy.get_action(context1, 2)
-        a4 = Action(4)
-        a5 = Action(5)
-        policy.add_action([a4, a5])
+        history_id, _ = policy.get_action(context1, 2)
+        new_actions = [Action() for i in range(2)]
+        policy.add_action(new_actions)
         policy.reward(history_id, {3: 1})
-        self.assertEqual(len(policy._actions), 5)
-        self.assertEqual(policy.action_ids, [1, 2, 3, 4, 5])
 
-
-if __name__ == '__main__':
-    unittest.main()
+        context2 = {1: [1, 1], 2: [2, 2], 3: [3, 3], 4: [4, 4], 5: [5, 5]}
+        history_id2, actions = policy.get_action(context2, 4)
+        self.assertEqual(len(actions), 4)
+        policy.reward(history_id2, {new_actions[0].id: 4, new_actions[1].id: 5})

--- a/striatum/bandit/tests/test_linucb.py
+++ b/striatum/bandit/tests/test_linucb.py
@@ -6,10 +6,12 @@ import numpy as np
 
 from striatum.bandit import LinUCB
 from striatum.storage import Action
-from .base_bandit_test import BaseBanditTest
+from .base_bandit_test import BaseBanditTest, ChangeableActionSetBanditTest
 
 
-class TestLinUCB(BaseBanditTest, unittest.TestCase):
+class TestLinUCB(ChangeableActionSetBanditTest,
+                 BaseBanditTest,
+                 unittest.TestCase):
     #pylint: disable=protected-access
 
     def setUp(self):

--- a/striatum/bandit/tests/test_linucb.py
+++ b/striatum/bandit/tests/test_linucb.py
@@ -12,7 +12,7 @@ from .base_bandit_test import BaseBanditTest, ChangeableActionSetBanditTest
 class TestLinUCB(ChangeableActionSetBanditTest,
                  BaseBanditTest,
                  unittest.TestCase):
-    #pylint: disable=protected-access
+    # pylint: disable=protected-access
 
     def setUp(self):
         super(TestLinUCB, self).setUp()
@@ -24,7 +24,9 @@ class TestLinUCB(ChangeableActionSetBanditTest,
 
     def test_initialization(self):
         super(TestLinUCB, self).test_initialization()
-        self.assertEqual(self.alpha, self.policy.alpha)
+        policy = self.policy
+        self.assertEqual(self.context_dimension, policy.context_dimension)
+        self.assertEqual(self.alpha, policy.alpha)
 
     def test_model_storage(self):
         model = self.policy._model_storage.get_model()
@@ -40,15 +42,18 @@ class TestLinUCB(ChangeableActionSetBanditTest,
         history_id, _ = policy.get_action(context1, 2)
         new_actions = [Action() for i in range(2)]
         policy.add_action(new_actions)
+        self.assertEqual(len(new_actions) + len(self.actions),
+                         policy._action_storage.count())
         policy.reward(history_id, {3: 1})
+        model = policy._model_storage.get_model()
         for action in new_actions:
-            self.assertTrue((policy._model_storage.get_model()['A'][action.id]
+            self.assertTrue((model['A'][action.id]
                              == np.identity(self.context_dimension)).all())
 
         context2 = {1: [1, 1], 2: [2, 2], 3: [3, 3], 4: [4, 4], 5: [5, 5]}
         history_id2, actions = policy.get_action(context2, 4)
         self.assertEqual(len(actions), 4)
         policy.reward(history_id2, {new_actions[0].id: 4, new_actions[1].id: 5})
+        model = policy._model_storage.get_model()
         for action in new_actions:
-            self.assertFalse((policy._model_storage.get_model()['A'][action.id]
-                              == np.identity(2)).all())
+            self.assertFalse((model['A'][action.id] == np.identity(2)).all())

--- a/striatum/bandit/tests/test_linucb.py
+++ b/striatum/bandit/tests/test_linucb.py
@@ -2,7 +2,10 @@
 """
 import unittest
 
+import numpy as np
+
 from striatum.bandit import LinUCB
+from striatum.storage import Action
 from .base_bandit_test import BaseBanditTest
 
 
@@ -28,3 +31,22 @@ class TestLinUCB(BaseBanditTest, unittest.TestCase):
         self.assertEqual(len(model['A']), self.action_storage.count())
         self.assertEqual(model['A'][1].shape,
                          (self.context_dimension, self.context_dimension))
+
+    def test_add_action(self):
+        policy = self.policy
+        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
+        history_id, _ = policy.get_action(context1, 2)
+        new_actions = [Action() for i in range(2)]
+        policy.add_action(new_actions)
+        policy.reward(history_id, {3: 1})
+        for action in new_actions:
+            self.assertTrue((policy._model_storage.get_model()['A'][action.id]
+                             == np.identity(self.context_dimension)).all())
+
+        context2 = {1: [1, 1], 2: [2, 2], 3: [3, 3], 4: [4, 4], 5: [5, 5]}
+        history_id2, actions = policy.get_action(context2, 4)
+        self.assertEqual(len(actions), 4)
+        policy.reward(history_id2, {new_actions[0].id: 4, new_actions[1].id: 5})
+        for action in new_actions:
+            self.assertFalse((policy._model_storage.get_model()['A'][action.id]
+                              == np.identity(2)).all())

--- a/striatum/bandit/tests/test_linucb.py
+++ b/striatum/bandit/tests/test_linucb.py
@@ -1,115 +1,30 @@
 """Unit test for LinUCB
 """
-
 import unittest
 
-import numpy as np
-
-from striatum.bandit import linucb
-from striatum.bandit.bandit import Action
-from striatum.storage import history, model
+from striatum.bandit import LinUCB
+from .base_bandit_test import BaseBanditTest
 
 
-class TestLinUcb(unittest.TestCase):
+class TestLinUCB(BaseBanditTest, unittest.TestCase):
+    #pylint: disable=protected-access
+
     def setUp(self):
-        self.modelstorage = model.MemoryModelStorage()
-        self.historystorage = history.MemoryHistoryStorage()
-        a1 = Action(1)
-        a2 = Action(2)
-        a3 = Action(3)
-        self.actions = [a1, a2, a3]
-        self.alpha = 1.00
+        super(TestLinUCB, self).setUp()
+        self.context_dimension = 2
+        self.alpha = 1.
+        self.policy = LinUCB(
+            self.history_storage, self.model_storage,
+            self.action_storage, self.alpha, self.context_dimension)
 
     def test_initialization(self):
-        policy = linucb.LinUCB(self.actions, self.historystorage,
-                               self.modelstorage, 1.00, 2)
-        self.assertEqual(self.actions, policy._actions)
-        self.assertEqual(1.00, policy.alpha)
-        self.assertEqual(2, policy.context_dimension)
-        self.assertEqual([1, 2, 3], policy.action_ids)
-
-    def test_get_first_action(self):
-        policy = linucb.LinUCB(self.actions, self.historystorage,
-                               self.modelstorage, 1.00, 2)
-        context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, action = policy.get_action(context, 1)
-        self.assertEqual(history_id, 0)
-        self.assertIn(action[0]['action'], self.actions)
-        self.assertEqual(
-            policy._historystorage.get_unrewarded_history(history_id).context, context)
-
-    def test_update_reward(self):
-        policy = linucb.LinUCB(self.actions, self.historystorage,
-                               self.modelstorage, 1.00, 2)
-        context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, _ = policy.get_action(context, 1)
-        policy.reward(history_id, {3: 1})
-        self.assertEqual(
-            policy._historystorage.get_history(history_id).reward, {3: 1})
+        super(TestLinUCB, self).test_initialization()
+        self.assertEqual(self.alpha, self.policy.alpha)
 
     def test_model_storage(self):
-        policy = linucb.LinUCB(self.actions, self.historystorage,
-                               self.modelstorage, 1.00, 2)
-        context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, _ = policy.get_action(context, 2)
-        policy.reward(history_id, {2: 1, 3: 1})
-        self.assertEqual(len(policy._modelstorage.get_model()['b']), 3)
-        self.assertEqual(len(policy._modelstorage.get_model()['b'][1]), 2)
-        self.assertEqual(len(policy._modelstorage.get_model()['A']), 3)
-        self.assertEqual(
-            policy._modelstorage.get_model()['A'][1].shape, (2, 2))
-
-    def test_delay_reward(self):
-        policy = linucb.LinUCB(self.actions, self.historystorage,
-                               self.modelstorage, 1.00, 2)
-        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        context2 = {1: [0, 0], 2: [3, 3], 3: [6, 6]}
-        history_id1, _ = policy.get_action(context1, 2)
-        history_id2, _ = policy.get_action(context2, 1)
-        policy.reward(history_id1, {2: 1, 3: 1})
-        self.assertEqual(
-            policy._historystorage.get_history(history_id1).context, context1)
-        self.assertEqual(
-            policy._historystorage.get_unrewarded_history(history_id2).context, context2)
-        self.assertEqual(
-            policy._historystorage.get_history(history_id1).reward,
-            {2: 1, 3: 1})
-        self.assertEqual(
-            policy._historystorage.get_unrewarded_history(history_id2).reward, None)
-
-    def test_reward_order_descending(self):
-        policy = linucb.LinUCB(self.actions, self.historystorage,
-                               self.modelstorage, 1.00, 2)
-        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        context2 = {1: [0, 0], 2: [3, 3], 3: [6, 6]}
-        history_id1, _ = policy.get_action(context1, 2)
-        history_id2, _ = policy.get_action(context2, 1)
-        policy.reward(history_id2, {3: 1})
-        self.assertEqual(
-            policy._historystorage.get_unrewarded_history(history_id1).context, context1)
-        self.assertEqual(
-            policy._historystorage.get_history(history_id2).context, context2)
-        self.assertEqual(
-            policy._historystorage.get_unrewarded_history(history_id1).reward, None)
-        self.assertEqual(
-            policy._historystorage.get_history(history_id2).reward, {3: 1})
-
-    def test_add_action(self):
-        policy = linucb.LinUCB(self.actions, self.historystorage,
-                               self.modelstorage, 1.00, 2)
-        context1 = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, _ = policy.get_action(context1, 2)
-        a4 = Action(4)
-        a5 = Action(5)
-        policy.add_action([a4, a5])
-        policy.reward(history_id, {3: 1})
-        self.assertTrue((policy._modelstorage.get_model()['A'][4] == np.identity(2)).all())
-
-        context2 = {1: [1, 1], 2: [2, 2], 3: [3, 3], 4: [4, 4], 5: [5, 5]}
-        history_id2, _ = policy.get_action(context2, 1)
-        policy.reward(history_id2, {4: 4, 5: 5})
-        self.assertFalse((policy._modelstorage.get_model()['A'][4] == np.identity(2)).all())
-
-
-if __name__ == '__main__':
-    unittest.main()
+        model = self.policy._model_storage.get_model()
+        self.assertEqual(len(model['b']), self.action_storage.count())
+        self.assertEqual(len(model['b'][1]), self.context_dimension)
+        self.assertEqual(len(model['A']), self.action_storage.count())
+        self.assertEqual(model['A'][1].shape,
+                         (self.context_dimension, self.context_dimension))

--- a/striatum/bandit/tests/test_ucb1.py
+++ b/striatum/bandit/tests/test_ucb1.py
@@ -1,74 +1,53 @@
 import unittest
-import sys
-sys.path.append("..")
-from striatum.storage import history as history
-from striatum.storage import model as model
-from striatum.bandit import ucb1
-from striatum.bandit.bandit import Action
+
+import numpy as np
+
+from striatum.bandit import UCB1
+from striatum.storage import Action
+from .base_bandit_test import BaseBanditTest, ChangeableActionSetBanditTest
 
 
-class Ucb1(unittest.TestCase):
+class TestUCB1(ChangeableActionSetBanditTest,
+               BaseBanditTest,
+               unittest.TestCase):
+    # pylint: disable=protected-access
+
     def setUp(self):
-        self.modelstorage = model.MemoryModelStorage()
-        self.historystorage = history.MemoryHistoryStorage()
-        a1 = Action(1)
-        a2 = Action(2)
-        a3 = Action(3)
-        a4 = Action(4)
-        a5 = Action(5)
-        self.actions = [a1, a2, a3, a4, a5]
-        self.alpha = 1.00
-
-    def test_initialization(self):
-        policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        self.assertEqual(self.actions, policy._actions)
-
-    def test_get_first_action(self):
-        policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_actions=1)
-        self.assertEqual(history_id, 0)
-        self.assertIn(action[0]['action'], self.actions)
-
-    def test_update_reward(self):
-        policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_actions=1)
-        policy.reward(history_id, {1: 0})
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 0})
+        super(TestUCB1, self).setUp()
+        self.policy = UCB1(
+            self.history_storage, self.model_storage, self.action_storage)
 
     def test_model_storage(self):
-        policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
+        policy = self.policy
         history_id, action = policy.get_action(context=None, n_actions=1)
-        policy.reward(history_id, {action[0]['action'].action_id: 1.0})
-        self.assertEqual(policy._modelstorage._model['empirical_reward'][action[0]['action'].action_id], 2)
-        self.assertEqual(policy._modelstorage._model['action_times'][action[0]['action'].action_id], 2.0)
-        self.assertEqual(policy._modelstorage._model['total_time'], 6.0)
-
-    def test_delay_reward(self):
-        policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_actions=1)
-        history_id_2, action_2 = policy.get_action(context=None, n_actions=1)
-        policy.reward(history_id, {1: 0})
-        self.assertEqual(policy._historystorage.get_history(history_id).reward, {1: 0})
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id_2).reward, None)
-
-    def test_reward_order_descending(self):
-        policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_actions=1)
-        history_id_2, action_2 = policy.get_action(context=None, n_actions=2)
-        policy.reward(history_id_2, {1: 0, 2: 0})
-        self.assertEqual(policy._historystorage.get_unrewarded_history(history_id).reward, None)
-        self.assertEqual(policy._historystorage.get_history(history_id_2).reward, {1: 0, 2: 0})
+        policy.reward(history_id, {action[0]['action'].id: 1.0})
+        model = policy._model_storage.get_model()
+        self.assertEqual(model['total_action_reward'][action[0]['action'].id],
+                         2.)
+        self.assertEqual(model['action_times'][action[0]['action'].id], 2)
+        self.assertEqual(model['n_rounds'], len(self.actions) + 1)
 
     def test_add_action(self):
-        policy = ucb1.UCB1(self.actions, self.historystorage, self.modelstorage)
-        history_id, action = policy.get_action(context=None, n_actions=1)
-        a6 = Action(6)
-        a7 = Action(7)
-        policy.add_action([a6, a7])
+        policy = self.policy
+        history_id, _ = policy.get_action(context=None, n_actions=2)
+        new_actions = [Action() for i in range(2)]
+        policy.add_action(new_actions)
+        self.assertEqual(len(new_actions) + len(self.actions),
+                         policy._action_storage.count())
         policy.reward(history_id, {3: 1})
-        self.assertEqual(len(policy._actions), 7)
-        self.assertEqual(policy.action_ids, [1, 2, 3, 4, 5, 6, 7])
+        model = policy._model_storage.get_model()
+        for action in new_actions:
+            self.assertEqual(model['total_action_reward'][action.id], 1.0)
+            self.assertEqual(model['action_times'][action.id], 1)
+            self.assertEqual(model['n_rounds'],
+                             len(self.actions) + len(new_actions) + 1)
 
-
-if __name__ == '__main__':
-    unittest.main()
+        history_id2, actions = policy.get_action(context=None, n_actions=4)
+        self.assertEqual(len(actions), 4)
+        policy.reward(history_id2, {new_actions[0].id: 4, new_actions[1].id: 5})
+        model = policy._model_storage.get_model()
+        for action in new_actions:
+            self.assertNotEqual(model['total_action_reward'][action.id], 1.0)
+            self.assertEqual(model['action_times'][action.id], 2)
+            self.assertEqual(model['n_rounds'],
+                             len(self.actions) + len(new_actions) + 1 + 2)

--- a/striatum/bandit/tests/test_ucb1.py
+++ b/striatum/bandit/tests/test_ucb1.py
@@ -1,7 +1,5 @@
 import unittest
 
-import numpy as np
-
 from striatum.bandit import UCB1
 from striatum.storage import Action
 from .base_bandit_test import BaseBanditTest, ChangeableActionSetBanditTest

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -130,16 +130,11 @@ class UCB1(BaseBandit):
         model = self._model_storage.get_model()
         total_action_reward = model['total_action_reward']
         action_times = model['action_times']
-        n_rounds = model['n_rounds']
         for action_id, reward in six.viewitems(rewards):
             total_action_reward[action_id] += reward
             action_times[action_id] += 1
-            n_rounds += 1
-        self._model_storage.save_model({
-            'total_action_reward': total_action_reward,
-            'action_times': action_times,
-            'n_rounds': n_rounds
-        })
+            model['n_rounds'] += 1
+        self._model_storage.save_model(model)
         # Update the history
         self._history_storage.add_reward(history_id, rewards)
 
@@ -160,5 +155,6 @@ class UCB1(BaseBandit):
         for action in actions:
             total_action_reward[action.id] = 1.0
             action_times[action.id] = 1
+            model['n_rounds'] += 1
 
         self._model_storage.save_model(model)

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -1,29 +1,27 @@
 """Upper Confidence Bound 1
-This module contains a class that implements UCB1 algorithm, a famous multi-armed bandit algorithm without context.
+This module contains a class that implements UCB1 algorithm, a famous
+multi-armed bandit algorithm without context.
 """
-
-import logging
+from __future__ import division
 import numpy as np
 import six
-from striatum.bandit.bandit import BaseBandit
 
-LOGGER = logging.getLogger(__name__)
+from striatum.bandit.bandit import BaseBandit
 
 
 class UCB1(BaseBandit):
-
-    """Upper Confidence Bound 1
+    r"""Upper Confidence Bound 1
 
     Parameters
     ----------
-    actions : {array-like, None}
-        Actions (arms) for recommendation
+    history_storage : HistoryStorage object
+        The HistoryStorage object to store history context, actions and rewards.
 
-    historystorage: a :py:mod:'striatum.storage.HistoryStorage' object
-        The object where we store the histories of contexts and rewards.
+    model_storage : ModelStorage object
+        The ModelStorage object to store model parameters.
 
-    modelstorage: a :py:mod:'straitum.storage.ModelStorage' object
-        The object where we store the model parameters.
+    action_storage : ActionStorage object
+        The ActionStorage object to store actions.
 
     Attributes
     ----------
@@ -32,40 +30,49 @@ class UCB1(BaseBandit):
 
     References
     ----------
-    .. [1]  Peter Auer, et al. "Finite-time Analysis of the Multiarmed Bandit Problem."
-            Machine Learning, 47. 2002.
+    .. [1]  Peter Auer, et al. "Finite-time Analysis of the Multiarmed Bandit
+            Problem." Machine Learning, 47. 2002.
     """
 
-    def __init__(self, actions, historystorage, modelstorage):
-        super(UCB1, self).__init__(historystorage, modelstorage, actions)
+    def __init__(self, history_storage, model_storage, action_storage):
+        super(UCB1, self).__init__(history_storage, model_storage,
+                                   action_storage)
         self.ucb1_ = None
-        empirical_reward = {}
+        total_action_reward = {}
         action_times = {}
-        for action_id in self.action_ids:
-            empirical_reward[action_id] = 1.0
-            action_times[action_id] = 1.0
-        total_time = float(len(self._actions))
-        self._modelstorage.save_model({'empirical_reward': empirical_reward,
-                                      'action_times': action_times, 'total_time': total_time})
+        for action_id in self._action_storage.iterids():
+            total_action_reward[action_id] = 1.0
+            action_times[action_id] = 1
+        n_rounds = self._action_storage.count()
+        self._model_storage.save_model({
+            'total_action_reward': total_action_reward,
+            'action_times': action_times,
+            'n_rounds': n_rounds,
+        })
 
     def ucb1(self):
         while True:
-            empirical_reward = self._modelstorage.get_model()['empirical_reward']
-            action_times = self._modelstorage.get_model()['action_times']
-            total_time = self._modelstorage.get_model()['total_time']
+            model = self._model_storage.get_model()
+            total_action_reward = model['total_action_reward']
+            action_times = model['action_times']
+            n_rounds = model['n_rounds']
 
-            estimated_reward = {}
-            uncertainty = {}
-            score = {}
-            for action_id in self.action_ids:
-                estimated_reward[action_id] = empirical_reward[action_id]/action_times[action_id]
-                uncertainty[action_id] = np.sqrt(2*np.log(total_time)/action_times[action_id])
-                score[action_id] = estimated_reward[action_id] + uncertainty[action_id]
-            yield estimated_reward, uncertainty, score
+            estimated_reward_dict = {}
+            uncertainty_dict = {}
+            score_dict = {}
+            for action_id in self._action_storage.iterids():
+                estimated_reward = (total_action_reward[action_id]
+                                    / action_times[action_id])
+                uncertainty = np.sqrt(2 * np.log(n_rounds)
+                                      / action_times[action_id])
+                estimated_reward_dict[action_id] = estimated_reward
+                uncertainty_dict[action_id] = uncertainty
+                score_dict[action_id] = estimated_reward + uncertainty
+            yield estimated_reward_dict, uncertainty_dict, score_dict
 
         raise StopIteration
 
-    def get_action(self, context, n_actions=1):
+    def get_action(self, context=None, n_actions=1):
         """Return the action to perform
 
         Parameters
@@ -82,9 +89,9 @@ class UCB1(BaseBandit):
             The history id of the action.
 
         action : list of dictionaries
-            In each dictionary, it will contains {Action object, estimated_reward, uncertainty}
+            In each dictionary, it will contains {Action object, estimated_
+            reward, uncertainty}
         """
-
         if self.ucb1_ is None:
             self.ucb1_ = self.ucb1()
             estimated_reward, uncertainty, score = six.next(self.ucb1_)
@@ -92,14 +99,19 @@ class UCB1(BaseBandit):
             estimated_reward, uncertainty, score = six.next(self.ucb1_)
 
         action_recommendation = []
-        actions_recommendation_ids = sorted(score, key=score.get, reverse=True)[:n_actions]
+        actions_recommendation_ids = sorted(score, key=score.get,
+                                            reverse=True)[:n_actions]
         for action_id in actions_recommendation_ids:
-            action_id = int(action_id)
-            action = [action for action in self._actions if action.action_id == action_id][0]
-            action_recommendation.append({'action': action, 'estimated_reward': estimated_reward[action_id],
-                                     'uncertainty': uncertainty[action_id], 'score': score[action_id]})
+            action = self._action_storage.get(action_id)
+            action_recommendation.append({
+                'action': action,
+                'estimated_reward': estimated_reward[action_id],
+                'uncertainty': uncertainty[action_id],
+                'score': score[action_id],
+            })
 
-        history_id = self._historystorage.add_history(context, action_recommendation, reward=None)
+        history_id = self._history_storage.add_history(
+            context, action_recommendation, reward=None)
         return history_id, action_recommendation
 
     def reward(self, history_id, rewards):
@@ -115,17 +127,21 @@ class UCB1(BaseBandit):
         """
 
         # Update the model
-        empirical_reward = self._modelstorage.get_model()['empirical_reward']
-        action_times = self._modelstorage.get_model()['action_times']
-        total_time = self._modelstorage.get_model()['total_time']
-        for action_id, reward_tmp in rewards.items():
-            empirical_reward[action_id] += reward_tmp
-            action_times[action_id] += 1.0
-            total_time += 1.0
-            self._modelstorage.save_model({'empirical_reward': empirical_reward,
-                                           'action_times': action_times, 'total_time': total_time})
+        model = self._model_storage.get_model()
+        total_action_reward = model['total_action_reward']
+        action_times = model['action_times']
+        n_rounds = model['n_rounds']
+        for action_id, reward in six.viewitems(rewards):
+            total_action_reward[action_id] += reward
+            action_times[action_id] += 1
+            n_rounds += 1
+        self._model_storage.save_model({
+            'total_action_reward': total_action_reward,
+            'action_times': action_times,
+            'n_rounds': n_rounds
+        })
         # Update the history
-        self._historystorage.add_reward(history_id, rewards)
+        self._history_storage.add_reward(history_id, rewards)
 
     def add_action(self, actions):
         """ Add new actions (if needed).
@@ -135,16 +151,14 @@ class UCB1(BaseBandit):
         actions : iterable
             A list of Action objects for recommendation
         """
-        action_ids = [actions[i].action_id for i in range(len(actions))]
-        self._actions.extend(actions)
+        self._action_storage.add(actions)
 
-        empirical_reward = self._modelstorage.get_model()['empirical_reward']
-        action_times = self._modelstorage.get_model()['action_times']
-        total_time = self._modelstorage.get_model()['total_time']
+        model = self._model_storage.get_model()
+        total_action_reward = model['total_action_reward']
+        action_times = model['action_times']
 
-        for action_id in self.action_ids:
-            empirical_reward[action_id] = 1.0
-            action_times[action_id] = 1.0
+        for action in actions:
+            total_action_reward[action.id] = 1.0
+            action_times[action.id] = 1
 
-        self._modelstorage.save_model({'empirical_reward': empirical_reward,
-                                       'action_times': action_times, 'total_time': total_time})
+        self._model_storage.save_model(model)

--- a/striatum/rewardplot.py
+++ b/striatum/rewardplot.py
@@ -14,16 +14,17 @@ def calculate_cum_reward(policy):
 
         Return
         ---------
-        cum_reward: dictionary
-            The dictionary stores {history_id: cumulative reward} .
+        cum_reward: dict
+            The dict stores {history_id: cumulative reward} .
 
-        cum_n_actions: dictionary
-            The dictionary stores {history_id: cumulative number of recommended actions} .
+        cum_n_actions: dict
+            The dict stores
+            {history_id: cumulative number of recommended actions}.
     """
     cum_reward = {-1: 0.0}
     cum_n_actions = {-1: 0}
-    for i in range(policy.historystorage.n_histories):
-        reward = policy.historystorage.get_history(i).reward
+    for i in range(policy.history_storage.n_histories):
+        reward = policy.history_storage.get_history(i).reward
         cum_n_actions[i] = cum_n_actions[i - 1] + len(reward)
         cum_reward[i] = cum_reward[i - 1] + sum(six.viewvalues(reward))
     return cum_reward, cum_n_actions
@@ -40,12 +41,12 @@ def calculate_avg_reward(policy):
 
         Return
         ---------
-        avg_reward: dictionary
-            The dictionary stores {history_id: average reward} .
+        avg_reward: dict
+            The dict stores {history_id: average reward} .
     """
     cum_reward, cum_n_actions = calculate_cum_reward(policy)
     avg_reward = {}
-    for i in range(policy.historystorage.n_histories):
+    for i in range(policy.history_storage.n_histories):
         avg_reward[i] = cum_reward[i] / cum_n_actions[i]
     return avg_reward
 
@@ -61,7 +62,8 @@ def plot_avg_reward(policy):
     """
 
     avg_reward = calculate_avg_reward(policy)
-    plt.plot(avg_reward.keys(), avg_reward.values(), 'r-', label="average reward")
+    plt.plot(avg_reward.keys(), avg_reward.values(), 'r-',
+             label="average reward")
     plt.xlabel('time')
     plt.ylabel('avg reward')
     plt.legend()

--- a/striatum/simulation.py
+++ b/striatum/simulation.py
@@ -89,7 +89,7 @@ def evaluate_policy(policy, context, desired_actions):
     cum_regret = np.empty(shape=n_rounds)
     for t in range(n_rounds):
         history_id, action = policy.get_action(context[t], 1)
-        action_id = action[0]['action'].action_id
+        action_id = action[0]['action'].id
         if desired_actions[t] != action_id:
             policy.reward(history_id, {action_id: 0})
             if t == 0:

--- a/striatum/simulation.py
+++ b/striatum/simulation.py
@@ -5,7 +5,7 @@ import matplotlib.pyplot as plt
 from .utils import get_random_state
 
 
-def simulate_data(n_rounds, context_dimension, actions, algorithm=None,
+def simulate_data(n_rounds, context_dimension, action_storage, algorithm=None,
                   random_state=None):
     """Simulate dataset for the contextual bandit problem.
 
@@ -17,8 +17,8 @@ def simulate_data(n_rounds, context_dimension, actions, algorithm=None,
     context_dimension: int
         Dimension of the context.
 
-    actions : list of Action objects
-        List of actions to be chosen from.
+    action_storage : ActionStorage object
+        The ActionStorage object to store actions.
 
     algorithm: string
         The bandit algorithm you want to use.
@@ -38,7 +38,7 @@ def simulate_data(n_rounds, context_dimension, actions, algorithm=None,
     """
     random_state = get_random_state(random_state)
 
-    action_ids = [action.action_id for action in actions]
+    action_ids = list(action_storage.iterids())
     context = {}
     desired_actions = {}
 
@@ -47,9 +47,10 @@ def simulate_data(n_rounds, context_dimension, actions, algorithm=None,
             context[t] = random_state.uniform(0, 1, context_dimension)
             context_sum = context[t].sum()
             for action_i, action_id in enumerate(action_ids):
-                if (action_i * context_dimension / len(actions)
+                if (action_i * context_dimension / action_storage.count()
                         < context_sum
-                        <= (action_i + 1) * context_dimension / len(actions)):
+                        <= ((action_i + 1) * context_dimension
+                            / action_storage.count())):
                     desired_actions[t] = action_id
 
     else:

--- a/striatum/storage/__init__.py
+++ b/striatum/storage/__init__.py
@@ -3,3 +3,4 @@
 
 from .model import MemoryModelStorage
 from .history import MemoryHistoryStorage
+from .action import MemoryActionStorage, Action

--- a/striatum/storage/action.py
+++ b/striatum/storage/action.py
@@ -4,6 +4,8 @@ Action storage
 from abc import abstractmethod
 from copy import deepcopy
 
+import six
+
 
 class Action(object):
     r"""The action object
@@ -19,6 +21,7 @@ class Action(object):
 
 
 class ActionStorage(object):
+
     @abstractmethod
     def get(self, action_id):
         r"""Get action by action id
@@ -35,8 +38,10 @@ class ActionStorage(object):
         """
         pass
 
+    @abstractmethod
     def add(self, action):
         r"""Add action
+
         Parameters
         ----------
         action: Action object
@@ -48,8 +53,10 @@ class ActionStorage(object):
         """
         pass
 
+    @abstractmethod
     def update(self, action):
         r"""Add action
+
         Parameters
         ----------
         action: Action object
@@ -61,8 +68,10 @@ class ActionStorage(object):
         """
         pass
 
+    @abstractmethod
     def remove(self, action_id):
         r"""Add action
+
         Parameters
         ----------
         action_id: int
@@ -74,11 +83,28 @@ class ActionStorage(object):
         """
         pass
 
+    @abstractmethod
+    def count(self):
+        r"""Count actions
+        """
+        pass
+
+    @abstractmethod
+    def iterids(self):
+        r"""Return iterable of the Action ids.
+
+        Returns
+        -------
+        action_ids: iterable
+            Action ids.
+        """
+
 
 class MemoryActionStorage(object):
+
     def __init__(self):
-        self.actions = {}
-        self.next_action_id = 0
+        self._actions = {}
+        self._next_action_id = 0
 
     def get(self, action_id):
         r"""Get action by action id
@@ -93,10 +119,11 @@ class MemoryActionStorage(object):
         action: Action object
             The Action object that has id action_id.
         """
-        return deepcopy(self.actions[action_id])
+        return deepcopy(self._actions[action_id])
 
     def add(self, action):
         r"""Add action
+
         Parameters
         ----------
         action: Action object
@@ -107,14 +134,17 @@ class MemoryActionStorage(object):
         KeyError
         """
         if action.id is None:
-            action.id = self.next_action_id
-            self.next_action_id += 1
-        elif action.id in self.actions:
+            action.id = self._next_action_id
+            self._next_action_id += 1
+        elif action.id in self._actions:
             raise KeyError("Action id {} exists".format(action.id))
-        self.actions[action.id] = action
+        else:
+            self._next_action_id = max(self._next_action_id, action.id + 1)
+        self._actions[action.id] = action
 
     def update(self, action):
-        r"""Add action
+        r"""Update action
+
         Parameters
         ----------
         action: Action object
@@ -124,10 +154,11 @@ class MemoryActionStorage(object):
         ------
         KeyError
         """
-        self.actions[action.id] = action
+        self._actions[action.id] = action
 
     def remove(self, action_id):
-        r"""Add action
+        r"""Remove action
+
         Parameters
         ----------
         action_id: int
@@ -137,5 +168,27 @@ class MemoryActionStorage(object):
         ------
         KeyError
         """
-        del self.actions[action_id]
+        del self._actions[action_id]
 
+    def count(self):
+        r"""Count actions
+
+        Returns
+        -------
+        count: int
+            Number of Action in the storage.
+        """
+        return len(self._actions)
+
+    def iterids(self):
+        r"""Return iterable of the Action ids.
+
+        Returns
+        -------
+        action_ids: iterable
+            Action ids.
+        """
+        return six.viewkeys(self._actions)
+
+    def __iter__(self):
+        return iter(six.viewvalues(self._actions))

--- a/striatum/storage/action.py
+++ b/striatum/storage/action.py
@@ -1,0 +1,141 @@
+"""
+Action storage
+"""
+from abc import abstractmethod
+from copy import deepcopy
+
+
+class Action(object):
+    r"""The action object
+
+    Parameters
+    ----------
+    action_id: int
+        The index of this action.
+    """
+
+    def __init__(self, action_id=None):
+        self.id = action_id
+
+
+class ActionStorage(object):
+    @abstractmethod
+    def get(self, action_id):
+        r"""Get action by action id
+
+        Parameters
+        ----------
+        action_id: int
+            The id of the action.
+
+        Returns
+        -------
+        action: Action object
+            The Action object that has id action_id.
+        """
+        pass
+
+    def add(self, action):
+        r"""Add action
+        Parameters
+        ----------
+        action: Action object
+            The Action object to add.
+
+        Raises
+        ------
+        KeyError
+        """
+        pass
+
+    def update(self, action):
+        r"""Add action
+        Parameters
+        ----------
+        action: Action object
+            The Action object to update.
+
+        Raises
+        ------
+        KeyError
+        """
+        pass
+
+    def remove(self, action_id):
+        r"""Add action
+        Parameters
+        ----------
+        action_id: int
+            The Action id to remove.
+
+        Raises
+        ------
+        KeyError
+        """
+        pass
+
+
+class MemoryActionStorage(object):
+    def __init__(self):
+        self.actions = {}
+        self.next_action_id = 0
+
+    def get(self, action_id):
+        r"""Get action by action id
+
+        Parameters
+        ----------
+        action_id: int
+            The id of the action.
+
+        Returns
+        -------
+        action: Action object
+            The Action object that has id action_id.
+        """
+        return deepcopy(self.actions[action_id])
+
+    def add(self, action):
+        r"""Add action
+        Parameters
+        ----------
+        action: Action object
+            The Action object to add.
+
+        Raises
+        ------
+        KeyError
+        """
+        if action.id is None:
+            action.id = self.next_action_id
+            self.next_action_id += 1
+        elif action.id in self.actions:
+            raise KeyError("Action id {} exists".format(action.id))
+        self.actions[action.id] = action
+
+    def update(self, action):
+        r"""Add action
+        Parameters
+        ----------
+        action: Action object
+            The Action object to update.
+
+        Raises
+        ------
+        KeyError
+        """
+        self.actions[action.id] = action
+
+    def remove(self, action_id):
+        r"""Add action
+        Parameters
+        ----------
+        action_id: int
+            The Action id to remove.
+
+        Raises
+        ------
+        KeyError
+        """
+        del self.actions[action_id]
+

--- a/striatum/storage/action.py
+++ b/striatum/storage/action.py
@@ -50,6 +50,11 @@ class ActionStorage(object):
         Raises
         ------
         KeyError
+
+        Returns
+        -------
+        new_action_ids: list of int
+            The Action ids of the added Actions.
         """
         pass
 
@@ -121,26 +126,35 @@ class MemoryActionStorage(object):
         """
         return deepcopy(self._actions[action_id])
 
-    def add(self, action):
-        r"""Add action
+    def add(self, actions):
+        r"""Add actions
 
         Parameters
         ----------
-        action: Action object
-            The Action object to add.
+        action: list of Action objects
+            The list of Action objects to add.
 
         Raises
         ------
         KeyError
+
+        Returns
+        -------
+        new_action_ids: list of int
+            The Action ids of the added Actions.
         """
-        if action.id is None:
-            action.id = self._next_action_id
-            self._next_action_id += 1
-        elif action.id in self._actions:
-            raise KeyError("Action id {} exists".format(action.id))
-        else:
-            self._next_action_id = max(self._next_action_id, action.id + 1)
-        self._actions[action.id] = action
+        new_action_ids = []
+        for action in actions:
+            if action.id is None:
+                action.id = self._next_action_id
+                self._next_action_id += 1
+            elif action.id in self._actions:
+                raise KeyError("Action id {} exists".format(action.id))
+            else:
+                self._next_action_id = max(self._next_action_id, action.id + 1)
+            self._actions[action.id] = action
+            new_action_ids.append(action.id)
+        return new_action_ids
 
     def update(self, action):
         r"""Update action

--- a/striatum/storage/history.py
+++ b/striatum/storage/history.py
@@ -7,6 +7,7 @@ from datetime import datetime
 
 class History(object):
     """action/reward history entry"""
+
     def __init__(self, history_id, action_time, context, action,
                  reward_time=None, reward=None):
         """
@@ -32,18 +33,6 @@ class History(object):
 
 class HistoryStorage(object):
     """The object to store the history of context, actions and rewards."""
-    # @property
-    # def histories(self):
-    #     """dictionary of history_id mapping to tuple (timestamp, context,
-    #     action, reward)"""
-    #     return self._histories
-
-    # @property
-    # def unrewarded_histories(self):
-    #     """dictionary of history_id mapping to tuple (timestamp, context,
-    #     action)"""
-    #     return self._unrewared_histories
-
     @abstractmethod
     def get_history(self, history_id):
         """Get the preivous context, action and reward with history_id.
@@ -113,6 +102,7 @@ class HistoryStorage(object):
 
 class MemoryHistoryStorage(HistoryStorage):
     """HistoryStorage that store all data in memory"""
+
     def __init__(self):
         self.histories = {}
         self.unrewarded_histories = {}
@@ -198,4 +188,3 @@ class MemoryHistoryStorage(HistoryStorage):
         history = self.unrewarded_histories.pop(history_id)
         history.update_reward(reward_time, reward)
         self.histories[history.history_id] = history
-

--- a/tox.ini
+++ b/tox.ini
@@ -10,5 +10,4 @@ envlist = py27,py34,py35
 deps =
     nose
     coverage
-    scikit-learn
 commands = nosetests


### PR DESCRIPTION
1. remove unneeded `scikit-learn` package dependency
2. `Action`
    1. move to `storage.action`
    2. use `self.id` as its ID (originally use `self.action_id`)
    3. the `action_id` in the constructor changed to be optional, and the id should be generated in `ActionStorage.add` if it's not given
3. `ActionStorage`
    1. `simulation.simulate_data`: change `actions` parameter to `action_storage`
    2. `Exp3`, `UCB1`, `LinUCB`, `LinThompSamp` constructors: remove `actions` and add `action_storage` as the third parameter
4. fix simulations for the new `Action` and `ActionStorage` design
5. all `historystorage` -> `history_storage`
6. all `memorystorage` -> `memory_storage`
7. fix coding style in `UCB1` and `Exp3`
8. fix `Exp3` not saving model in `add_action` bug
9. temporarily abandon support of `Exp4p`
10. refactor tests for bandit