### PR TITLE
reorder bandit init parameter; change default value; resolved #96

### DIFF
--- a/simulation/simulation_linucb.py
+++ b/simulation/simulation_linucb.py
@@ -27,7 +27,7 @@ def main():
         policy = LinUCB(history_storage=MemoryHistoryStorage(),
                         model_storage=MemoryModelStorage(),
                         action_storage=action_storage,
-                        alpha=alpha, context_dimension=context_dimension)
+                        context_dimension=context_dimension, alpha=alpha)
         cum_regret = simulation.evaluate_policy(policy, context1,
                                                 desired_actions1)
         ctr_tuning[alpha_i] = n_rounds - cum_regret[-1]
@@ -43,7 +43,7 @@ def main():
     policy = LinUCB(history_storage=MemoryHistoryStorage(),
                     model_storage=MemoryModelStorage(),
                     action_storage=action_storage,
-                    alpha=alpha_opt, context_dimension=context_dimension)
+                    context_dimension=context_dimension, alpha=alpha_opt)
 
     for t in range(n_rounds):
         history_id, action = policy.get_action(context2[t], 1)

--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -42,8 +42,8 @@ class Exp3(BaseBandit):
             multi-armed bandit problem ." SIAM Journal of Computing. 2002.
     """
 
-    def __init__(self, history_storage, model_storage, action_storage, gamma,
-                 random_state=None):
+    def __init__(self, history_storage, model_storage, action_storage,
+                 gamma=0.3, random_state=None):
         super(Exp3, self).__init__(history_storage, model_storage,
                                    action_storage)
         self.random_state = get_random_state(random_state)

--- a/striatum/bandit/linthompsamp.py
+++ b/striatum/bandit/linthompsamp.py
@@ -57,7 +57,7 @@ class LinThompSamp(BaseBandit):
     """
 
     def __init__(self, history_storage, model_storage, action_storage,
-                 context_dimension, delta=0.5, R=0.5, epsilon=0.1,
+                 context_dimension=128, delta=0.5, R=0.01, epsilon=0.5,
                  random_state=None):
         super(LinThompSamp, self).__init__(history_storage, model_storage,
                                            action_storage)

--- a/striatum/bandit/linucb.py
+++ b/striatum/bandit/linucb.py
@@ -47,8 +47,8 @@ class LinUCB(BaseBandit):
             International Conference on World Wide Web (WWW), 2010.
     """
 
-    def __init__(self, history_storage, model_storage, action_storage, alpha,
-                 context_dimension=1):
+    def __init__(self, history_storage, model_storage, action_storage,
+                 context_dimension=128, alpha=0.5):
         super(LinUCB, self).__init__(history_storage, model_storage,
                                      action_storage)
         self.alpha = alpha

--- a/striatum/bandit/tests/test_linucb.py
+++ b/striatum/bandit/tests/test_linucb.py
@@ -20,7 +20,7 @@ class TestLinUCB(ChangeableActionSetBanditTest,
         self.alpha = 1.
         self.policy = LinUCB(
             self.history_storage, self.model_storage,
-            self.action_storage, self.alpha, self.context_dimension)
+            self.action_storage, self.context_dimension, self.alpha)
 
     def test_initialization(self):
         super(TestLinUCB, self).test_initialization()


### PR DESCRIPTION
resolved #96

1. Exp3: 

    before:
    ```python
    def __init__(self, history_storage, model_storage, action_storage, gamma,
                 random_state=None):
    ```
    after:
    ```python
    def __init__(self, history_storage, model_storage, action_storage,
                 gamma=0.3, random_state=None):
    ```

2. LinUCB

    before:
    ```python
    def __init__(self, history_storage, model_storage, action_storage, alpha,
                 context_dimension=1):
    ```
    after:
    ```python
    def __init__(self, history_storage, model_storage, action_storage,
                 context_dimension=128, alpha=0.5):
    ```

3. LinThompSamp

    before:
    ```python
    def __init__(self, history_storage, model_storage, action_storage,
                 context_dimension, delta=0.5, R=0.5, epsilon=0.1,
                 random_state=None):
    ```
    after:
    ```python
    def __init__(self, history_storage, model_storage, action_storage,
                 context_dimension=128, delta=0.5, R=0.01, epsilon=0.5,
                 random_state=None):
    ```
