### PR TITLE
unify the data usage in all simulations, resolved #95

### DIFF
--- a/simulation/simulation_exp3.py
+++ b/simulation/simulation_exp3.py
@@ -22,7 +22,7 @@ def main():
     tuning_region = np.arange(0.001, 1, 0.03)
     ctr_tuning = np.zeros(shape=len(tuning_region))
     context1, desired_actions1 = simulation.simulate_data(
-        n_rounds, context_dimension, action_storage, random_state=random_state)
+        n_rounds, context_dimension, action_storage, random_state=0)
     for gamma_i, gamma in enumerate(tuning_region):
         policy = Exp3(MemoryHistoryStorage(), MemoryModelStorage(),
                       action_storage, gamma, random_state=random_state)
@@ -37,7 +37,7 @@ def main():
     # Regret Analysis
     n_rounds = 10000
     context2, desired_actions2 = simulation.simulate_data(
-        n_rounds, context_dimension, action_storage, random_state=random_state)
+        n_rounds, context_dimension, action_storage, random_state=1)
     policy = Exp3(MemoryHistoryStorage(), MemoryModelStorage(),
                   action_storage, gamma=gamma_opt, random_state=random_state)
 

--- a/simulation/simulation_exp4p.py
+++ b/simulation/simulation_exp4p.py
@@ -38,17 +38,16 @@ def get_advice(context, action_ids, experts):
 def main():  # pylint: disable=too-many-locals
     n_rounds = 1000
     context_dimension = 5
-    actions = [Action(i) for i in range(1, 6)]
-    action_ids = [1, 2, 3, 4, 5]
-    history_context, history_action = simulation.simulate_data(
+    actions = [Action(i) for i in range(5)]
+
+    action_ids = [0, 1, 2, 3, 4]
+    context1, desired_actions1 = simulation.simulate_data(
         3000, context_dimension, actions, "Exp4P", random_state=0)
-    experts = train_expert(history_context, history_action)
+    experts = train_expert(context1, desired_actions1)
 
     # Parameter tuning
     tuning_region = np.arange(0.01, 1, 0.05)
     ctr_tuning = np.empty(len(tuning_region))
-    context1, desired_actions1 = simulation.simulate_data(
-        n_rounds, context_dimension, actions, "Exp4P", random_state=1)
     advice1 = get_advice(context1, action_ids, experts)
 
     for delta_i, delta in enumerate(tuning_region):
@@ -67,7 +66,7 @@ def main():  # pylint: disable=too-many-locals
     # Regret Analysis
     n_rounds = 10000
     context2, desired_actions2 = simulation.simulate_data(
-        n_rounds, context_dimension, actions, "Exp4P", random_state=2)
+        n_rounds, context_dimension, actions, "Exp4P", random_state=1)
     advice2 = get_advice(context2, action_ids, experts)
     historystorage = MemoryHistoryStorage()
     modelstorage = MemoryModelStorage()

--- a/simulation/simulation_linthompsamp.py
+++ b/simulation/simulation_linthompsamp.py
@@ -26,7 +26,7 @@ def main():
     ctr_epsilon = np.zeros(shape=len(tuning_region))
 
     context1, desired_actions1 = simulation.simulate_data(
-        n_rounds, context_dimension, action_storage, random_state=random_state)
+        n_rounds, context_dimension, action_storage, random_state=0)
 
     for param_i, param in enumerate(tuning_region):
         policy = LinThompSamp(MemoryHistoryStorage(), MemoryModelStorage(),
@@ -82,7 +82,7 @@ def main():
     # Regret Analysis
     n_rounds = 10000
     context2, desired_actions2 = simulation.simulate_data(
-        n_rounds, context_dimension, action_storage, random_state=random_state)
+        n_rounds, context_dimension, action_storage, random_state=1)
     policy = LinThompSamp(MemoryHistoryStorage(), MemoryModelStorage(),
                           action_storage,
                           context_dimension=context_dimension,

--- a/simulation/simulation_ucb1.py
+++ b/simulation/simulation_ucb1.py
@@ -17,9 +17,9 @@ def main():
     action_storage.add([Action(i) for i in range(5)])
 
     # Regret Analysis
-    n_rounds = 40000
+    n_rounds = 10000
     context, desired_actions = simulation.simulate_data(
-        n_rounds, context_dimension, action_storage, random_state=0)
+        n_rounds, context_dimension, action_storage, random_state=1)
     policy = UCB1(MemoryHistoryStorage(), MemoryModelStorage(),
                   action_storage)
 


### PR DESCRIPTION
resolved #95
1. Exp3
![figure_1](https://cloud.githubusercontent.com/assets/4056670/19713671/82341cfc-9b7a-11e6-86aa-b84d80d353ab.png)
![figure_1-1](https://cloud.githubusercontent.com/assets/4056670/19713669/7e390860-9b7a-11e6-84ab-c506aece2ef2.png)
2. UCB1
![figure_1-6](https://cloud.githubusercontent.com/assets/4056670/19713674/8f9f140a-9b7a-11e6-921f-cc5965c796f9.png)
3. LinUCB (doesn't change)
![figure_1-2](https://cloud.githubusercontent.com/assets/4056670/19713680/9e1cf290-9b7a-11e6-8d2a-7cdbd5494a15.png)
![figure_1-3](https://cloud.githubusercontent.com/assets/4056670/19713681/9fc0ac90-9b7a-11e6-9b1a-f51f428ff830.png)
4. LinThompSamp
![figure_1-4](https://cloud.githubusercontent.com/assets/4056670/19713691/a9d00a8c-9b7a-11e6-8ecd-0dac7f48f03d.png)
![figure_1-5](https://cloud.githubusercontent.com/assets/4056670/19713686/a707d140-9b7a-11e6-936c-c71d88bfd15e.png)