### PR TITLE
Multi action history, resolved #58

### DIFF
--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -62,8 +62,8 @@ class BaseBandit(object):
         history_id : int
             The history id of the action.
 
-        action_recommendation : list of dictionaries
-            Each dictionary contains
+        recommendations : list of dict
+            Each dict contains
             {Action object, estimated_reward, uncertainty}.
         """
         pass

--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -113,9 +113,9 @@ class Exp3(BaseBandit):
         history_id : int
             The history id of the action.
 
-        action_recommendation : list of dictionaries
-            In each dictionary, it will contains {Action object,
-            estimated_reward, uncertainty}
+        recommendations : list of dict
+            Each dict contains
+            {Action object, estimated_reward, uncertainty}.
         """
         estimated_reward, uncertainty, score = self._exp3_score()
         if n_actions == -1:
@@ -124,29 +124,28 @@ class Exp3(BaseBandit):
         action_ids = list(six.viewkeys(estimated_reward))
         query_vector = np.asarray([estimated_reward[action_id]
                                    for action_id in action_ids])
-        action_recommendation_ids = self.random_state.choice(
+        recommendation_ids = self.random_state.choice(
             action_ids, size=n_actions, p=query_vector, replace=False)
 
         if n_actions is None:
-            action_recommendation = {
-                'action': self._action_storage.get(action_recommendation_ids),
-                'estimated_reward': estimated_reward[action_recommendation_ids],
-                'uncertainty': uncertainty[action_recommendation_ids],
-                'score': score[action_recommendation_ids],
+            recommendations = {
+                'action': self._action_storage.get(recommendation_ids),
+                'estimated_reward': estimated_reward[recommendation_ids],
+                'uncertainty': uncertainty[recommendation_ids],
+                'score': score[recommendation_ids],
             }
         else:
-            action_recommendation = []  # pylint: disable=redefined-variable-type
-            for action_id in action_recommendation_ids:
-                action_recommendation.append({
+            recommendations = []  # pylint: disable=redefined-variable-type
+            for action_id in recommendation_ids:
+                recommendations.append({
                     'action': self._action_storage.get(action_id),
                     'estimated_reward': estimated_reward[action_id],
                     'uncertainty': uncertainty[action_id],
                     'score': score[action_id],
                 })
 
-        history_id = self._history_storage.add_history(
-            context, action_recommendation, reward=None)
-        return history_id, action_recommendation
+        history_id = self._history_storage.add_history(context, recommendations)
+        return history_id, recommendations
 
     def reward(self, history_id, rewards):
         """Reward the previous action with reward.

--- a/striatum/bandit/linthompsamp.py
+++ b/striatum/bandit/linthompsamp.py
@@ -137,9 +137,9 @@ class LinThompSamp(BaseBandit):
         history_id : int
             The history id of the action.
 
-        action_recommendation : list of dictionaries
-            In each dictionary, it contains {Action object,
-            estimated_reward, uncertainty}.
+        recommendations : list of dict
+            Each dict contains
+            {Action object, estimated_reward, uncertainty}.
         """
         if not isinstance(context, dict):
             raise ValueError(
@@ -150,28 +150,27 @@ class LinThompSamp(BaseBandit):
         estimated_reward, uncertainty, score = self._linthompsamp_score(context)
 
         if n_actions is None:
-            action_recommendation_id = max(score, key=score.get)
-            action_recommendation = {
-                'action': self._action_storage.get(action_recommendation_id),
-                'estimated_reward': estimated_reward[action_recommendation_id],
-                'uncertainty': uncertainty[action_recommendation_id],
-                'score': score[action_recommendation_id],
+            recommendation_id = max(score, key=score.get)
+            recommendations = {
+                'action': self._action_storage.get(recommendation_id),
+                'estimated_reward': estimated_reward[recommendation_id],
+                'uncertainty': uncertainty[recommendation_id],
+                'score': score[recommendation_id],
             }
         else:
-            action_recommendation_ids = sorted(score, key=score.get,
-                                               reverse=True)[:n_actions]
-            action_recommendation = []  # pylint: disable=redefined-variable-type
-            for action_id in action_recommendation_ids:
-                action_recommendation.append({
+            recommendation_ids = sorted(score, key=score.get,
+                                        reverse=True)[:n_actions]
+            recommendations = []  # pylint: disable=redefined-variable-type
+            for action_id in recommendation_ids:
+                recommendations.append({
                     'action': self._action_storage.get(action_id),
                     'estimated_reward': estimated_reward[action_id],
                     'uncertainty': uncertainty[action_id],
                     'score': score[action_id],
                 })
 
-        history_id = self._history_storage.add_history(
-            context, action_recommendation, reward=None)
-        return history_id, action_recommendation
+        history_id = self._history_storage.add_history(context, recommendations)
+        return history_id, recommendations
 
     def reward(self, history_id, rewards):
         """Reward the previous action with reward.

--- a/striatum/bandit/linucb.py
+++ b/striatum/bandit/linucb.py
@@ -120,9 +120,9 @@ class LinUCB(BaseBandit):
         history_id : int
             The history id of the action.
 
-        action_recommendation : list of dict
-            Each dict contains {Action object, estimated_reward,
-            uncertainty}
+        recommendations : list of dict
+            Each dict contains
+            {Action object, estimated_reward, uncertainty}.
         """
         if not isinstance(context, dict):
             raise ValueError("LinUCB requires context dict for all actions!")
@@ -132,28 +132,27 @@ class LinUCB(BaseBandit):
         estimated_reward, uncertainty, score = self._linucb_score(context)
 
         if n_actions is None:
-            action_recommendation_id = max(score, key=score.get)
-            action_recommendation = {
-                'action': self._action_storage.get(action_recommendation_id),
-                'estimated_reward': estimated_reward[action_recommendation_id],
-                'uncertainty': uncertainty[action_recommendation_id],
-                'score': score[action_recommendation_id],
+            recommendation_id = max(score, key=score.get)
+            recommendations = {
+                'action': self._action_storage.get(recommendation_id),
+                'estimated_reward': estimated_reward[recommendation_id],
+                'uncertainty': uncertainty[recommendation_id],
+                'score': score[recommendation_id],
             }
         else:
-            action_recommendation_ids = sorted(score, key=score.get,
-                                               reverse=True)[:n_actions]
-            action_recommendation = []  # pylint: disable=redefined-variable-type
-            for action_id in action_recommendation_ids:
-                action_recommendation.append({
+            recommendation_ids = sorted(score, key=score.get,
+                                        reverse=True)[:n_actions]
+            recommendations = []  # pylint: disable=redefined-variable-type
+            for action_id in recommendation_ids:
+                recommendations.append({
                     'action': self._action_storage.get(action_id),
                     'estimated_reward': estimated_reward[action_id],
                     'uncertainty': uncertainty[action_id],
                     'score': score[action_id],
                 })
 
-        history_id = self._history_storage.add_history(
-            context, action_recommendation, reward=None)
-        return history_id, action_recommendation
+        history_id = self._history_storage.add_history(context, recommendations)
+        return history_id, recommendations
 
     def reward(self, history_id, rewards):
         """Reward the previous action with reward.

--- a/striatum/bandit/tests/base_bandit_test.py
+++ b/striatum/bandit/tests/base_bandit_test.py
@@ -78,7 +78,7 @@ class BaseBanditTest(object):
         history_id, _ = policy.get_action(context, 1)
         policy.reward(history_id, {3: 1})
         self.assertEqual(
-            policy._history_storage.get_history(history_id).reward,
+            policy._history_storage.get_history(history_id).rewards,
             {3: 1})
 
     def test_delay_reward(self):
@@ -96,10 +96,10 @@ class BaseBanditTest(object):
             policy._history_storage.get_unrewarded_history(history_id2).context,
             context2)
         self.assertDictEqual(
-            policy._history_storage.get_history(history_id1).reward,
+            policy._history_storage.get_history(history_id1).rewards,
             {2: 1, 3: 1})
         self.assertIsNone(
-            policy._history_storage.get_unrewarded_history(history_id2).reward)
+            policy._history_storage.get_unrewarded_history(history_id2).rewards)
 
     def test_reward_order_descending(self):
         policy = self.policy
@@ -114,9 +114,9 @@ class BaseBanditTest(object):
         self.assertDictEqual(
             policy._history_storage.get_history(history_id2).context, context2)
         self.assertIsNone(
-            policy._history_storage.get_unrewarded_history(history_id1).reward)
+            policy._history_storage.get_unrewarded_history(history_id1).rewards)
         self.assertDictEqual(
-            policy._history_storage.get_history(history_id2).reward, {3: 1})
+            policy._history_storage.get_history(history_id2).rewards, {3: 1})
 
 
 class ChangeableActionSetBanditTest(object):

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -95,28 +95,27 @@ class UCB1(BaseBandit):
             n_actions = self._action_storage.count()
 
         if n_actions is None:
-            action_recommendation_id = max(score, key=score.get)
-            action_recommendation = {
-                'action': self._action_storage.get(action_recommendation_id),
-                'estimated_reward': estimated_reward[action_recommendation_id],
-                'uncertainty': uncertainty[action_recommendation_id],
-                'score': score[action_recommendation_id],
+            recommendation_id = max(score, key=score.get)
+            recommendations = {
+                'action': self._action_storage.get(recommendation_id),
+                'estimated_reward': estimated_reward[recommendation_id],
+                'uncertainty': uncertainty[recommendation_id],
+                'score': score[recommendation_id],
             }
         else:
             action_recommendation_ids = sorted(score, key=score.get,
                                                reverse=True)[:n_actions]
-            action_recommendation = []  # pylint: disable=redefined-variable-type
+            recommendations = []  # pylint: disable=redefined-variable-type
             for action_id in action_recommendation_ids:
-                action_recommendation.append({
+                recommendations.append({
                     'action': self._action_storage.get(action_id),
                     'estimated_reward': estimated_reward[action_id],
                     'uncertainty': uncertainty[action_id],
                     'score': score[action_id],
                 })
 
-        history_id = self._history_storage.add_history(
-            context, action_recommendation, reward=None)
-        return history_id, action_recommendation
+        history_id = self._history_storage.add_history(context, recommendations)
+        return history_id, recommendations
 
     def reward(self, history_id, rewards):
         """Reward the previous action with reward.

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -86,9 +86,9 @@ class UCB1(BaseBandit):
         history_id : int
             The history id of the action.
 
-        action : list of dictionaries
-            In each dictionary, it will contains {Action object, estimated_
-            reward, uncertainty}
+        recommendations : list of dict
+            Each dict contains
+            {Action object, estimated_reward, uncertainty}.
         """
         estimated_reward, uncertainty, score = self._ucb1_score()
         if n_actions == -1:
@@ -103,10 +103,10 @@ class UCB1(BaseBandit):
                 'score': score[recommendation_id],
             }
         else:
-            action_recommendation_ids = sorted(score, key=score.get,
-                                               reverse=True)[:n_actions]
+            recommendation_ids = sorted(score, key=score.get,
+                                        reverse=True)[:n_actions]
             recommendations = []  # pylint: disable=redefined-variable-type
-            for action_id in action_recommendation_ids:
+            for action_id in recommendation_ids:
                 recommendations.append({
                     'action': self._action_storage.get(action_id),
                     'estimated_reward': estimated_reward[action_id],

--- a/striatum/storage/action.py
+++ b/striatum/storage/action.py
@@ -105,7 +105,7 @@ class ActionStorage(object):
         """
 
 
-class MemoryActionStorage(object):
+class MemoryActionStorage(ActionStorage):
 
     def __init__(self):
         self._actions = {}

--- a/striatum/storage/history.py
+++ b/striatum/storage/history.py
@@ -196,7 +196,7 @@ class MemoryHistoryStorage(HistoryStorage):
         Raise
         -----
         """
-        reward_time = datetime.now()
+        rewarded_at = datetime.now()
         history = self.unrewarded_histories.pop(history_id)
-        history.update_reward(reward_time, rewards)
+        history.update_reward(rewards, rewarded_at)
         self.histories[history.history_id] = history

--- a/striatum/storage/history.py
+++ b/striatum/storage/history.py
@@ -44,7 +44,7 @@ class HistoryStorage(object):
     """
     @abstractmethod
     def get_history(self, history_id):
-        """Get the preivous context, recommendations and rewards with
+        """Get the previous context, recommendations and rewards with
         history_id.
 
         Parameters
@@ -54,7 +54,7 @@ class HistoryStorage(object):
 
         Returns
         -------
-        history: History object
+        history: History
 
         Raise
         -----
@@ -74,7 +74,7 @@ class HistoryStorage(object):
 
         Returns
         -------
-        history: History object
+        history: History
 
         Raise
         -----
@@ -122,25 +122,7 @@ class MemoryHistoryStorage(HistoryStorage):
         self.n_histories = 0
 
     def get_history(self, history_id):
-        """Get the previous context, action and reward with history_id.
-
-        Parameters
-        ----------
-        history_id : int
-            The history id of the history record to retrieve.
-
-        Returns
-        -------
-        history: History object
-
-        Raise
-        -----
-        KeyError
-        """
-        return self.histories[history_id]
-
-    def get_unrewarded_history(self, history_id):
-        """Get the previous unrewarded context, action and reward with
+        """Get the previous context, recommendations and rewards with
         history_id.
 
         Parameters
@@ -150,7 +132,26 @@ class MemoryHistoryStorage(HistoryStorage):
 
         Returns
         -------
-        history: History object
+        history: History
+
+        Raise
+        -----
+        KeyError
+        """
+        return self.histories[history_id]
+
+    def get_unrewarded_history(self, history_id):
+        """Get the previous unrewarded context, recommendations and rewards with
+        history_id.
+
+        Parameters
+        ----------
+        history_id : int
+            The history id of the history record to retrieve.
+
+        Returns
+        -------
+        history: History
 
         Raise
         -----
@@ -158,46 +159,44 @@ class MemoryHistoryStorage(HistoryStorage):
         """
         return self.unrewarded_histories[history_id]
 
-    def add_history(self, context, action, reward=None):
+    def add_history(self, context, recommendations, rewards=None):
         """Add a history record.
 
         Parameters
         ----------
-        context : {array-like, None}
-        action : Action object
-        reward : {float, None}, optional (default: None)
+        context : {dict of list of float, None}
+        recommendations : {Recommendation, list of Recommendation}
+        rewards : {float, dict of float, None}
 
         Raise
         -----
         """
-        action_time = datetime.now()
+        created_at = datetime.now()
         history_id = self.n_histories
-        if reward is None:
-            history = History(history_id, action_time, context, action)
+        if rewards is None:
+            history = History(history_id, context, recommendations, created_at)
             self.unrewarded_histories[history_id] = history
         else:
-            reward_time = action_time
-            history = History(history_id, action_time, context, action,
-                              reward_time, reward)
+            rewarded_at = created_at
+            history = History(history_id, context, recommendations, created_at,
+                              rewards, rewarded_at)
             self.histories[history_id] = history
         self.n_histories += 1
         return history_id
 
-    def add_reward(self, history_id, reward):
+    def add_reward(self, history_id, rewards):
         """Add reward to a history record.
 
         Parameters
         ----------
         history_id : int
             The history id of the history record to retrieve.
-
-        reward : float
+        rewards : {float, dict of float, None}
 
         Raise
         -----
-        KeyError
         """
         reward_time = datetime.now()
         history = self.unrewarded_histories.pop(history_id)
-        history.update_reward(reward_time, reward)
+        history.update_reward(reward_time, rewards)
         self.histories[history.history_id] = history

--- a/striatum/storage/history.py
+++ b/striatum/storage/history.py
@@ -6,51 +6,45 @@ from datetime import datetime
 
 
 class History(object):
-    """action/reward history entry"""
+    """action/reward history entry.
 
-    def __init__(self, history_id, action_time, context, action,
-                 reward_time=None, reward=None):
-        """
-        history_id : int
-        action_time : datetime
-        context : {array-like, None}
-        action : Action object
-        reward_time : datetime
-        reward : {float, None}
-        """
+    Parameters
+    ----------
+    history_id : int
+    context : {dict of list of float, None}
+    recommendations : {Recommendation, list of Recommendation}
+    created_at : datetime
+    rewards : {float, dict of float, None}
+    rewarded_at : {datetime, None}
+    """
+
+    def __init__(self, history_id, context, recommendations, created_at,
+                 rewards=None, rewarded_at=None):
         self.history_id = history_id
-        self.action_time = action_time
         self.context = context
-        self.action = action
-        self.reward_time = reward_time
-        self.reward = reward
+        self.recommendations = recommendations
+        self.created_at = created_at
+        self.rewards = rewards
+        self.rewarded_at = rewarded_at
 
-    def update_reward(self, reward_time, reward):
-        """update reward_time and reward"""
-        self.reward_time = reward_time
-        self.reward = reward
-
-
-class HistoryStorage(object):
-    """The object to store the history of context, actions and rewards."""
-    @abstractmethod
-    def get_history(self, history_id):
-        """Get the preivous context, action and reward with history_id.
+    def update_reward(self, rewards, rewarded_at):
+        """Update reward_time and rewards.
 
         Parameters
         ----------
-        history_id : int
-            The history id of the history record to retrieve.
-
-        Returns
-        -------
-        history: History object
+        rewards : {float, dict of float, None}
+        rewarded_at : {datetime, None}
         """
-        pass
+        self.rewards = rewards
+        self.rewarded_at = rewarded_at
 
+
+class HistoryStorage(object):
+    """The object to store the history of context, recommendations and rewards.
+    """
     @abstractmethod
-    def get_unrewarded_history(self, history_id):
-        """Get the previous unrewarded context, action and reward with
+    def get_history(self, history_id):
+        """Get the preivous context, recommendations and rewards with
         history_id.
 
         Parameters
@@ -69,14 +63,34 @@ class HistoryStorage(object):
         pass
 
     @abstractmethod
-    def add_history(self, context, action, reward=None):
+    def get_unrewarded_history(self, history_id):
+        """Get the previous unrewarded context, recommendations and rewards with
+        history_id.
+
+        Parameters
+        ----------
+        history_id : int
+            The history id of the history record to retrieve.
+
+        Returns
+        -------
+        history: History object
+
+        Raise
+        -----
+        KeyError
+        """
+        pass
+
+    @abstractmethod
+    def add_history(self, context, recommendations, rewards=None):
         """Add a history record.
 
         Parameters
         ----------
-        context : {array-like, None}
-        action : Action object
-        reward : {float, None}, optional (default: None)
+        context : {dict of list of float, None}
+        recommendations : {Recommendation, list of Recommendation}
+        rewards : {float, dict of float, None}
 
         Raise
         -----
@@ -84,15 +98,14 @@ class HistoryStorage(object):
         pass
 
     @abstractmethod
-    def add_reward(self, history_id, reward):
+    def add_reward(self, history_id, rewards):
         """Add reward to a history record.
 
         Parameters
         ----------
         history_id : int
             The history id of the history record to retrieve.
-
-        reward : float
+        rewards : {float, dict of float, None}
 
         Raise
         -----


### PR DESCRIPTION
resolved #58 
also change the naming convention: action option and the action itself should be called `action`, and the action that is returned by the algorithm should be called `recommendation`. 
breaking changes:
1. the parameter name in `History` and `HistoryStorage` is changed
2. the parameter order in `History` is changed