### PR TITLE
Exp3 support out of order reward, resolved #108

### DIFF
--- a/striatum/bandit/tests/base_bandit_test.py
+++ b/striatum/bandit/tests/base_bandit_test.py
@@ -28,10 +28,11 @@ class BaseBanditTest(object):
     def test_get_first_action(self):
         policy = self.policy
         context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, action = policy.get_action(context, 1)
+        history_id, recommendations = policy.get_action(context, 1)
         self.assertEqual(history_id, 0)
-        self.assertEqual(len(action), 1)
-        self.assertIn(action[0]['action'].id, self.action_storage.iterids())
+        self.assertEqual(len(recommendations), 1)
+        self.assertIn(recommendations[0]['action'].id,
+                      self.action_storage.iterids())
         self.assertEqual(
             policy._history_storage.get_unrewarded_history(history_id).context,
             context)
@@ -39,10 +40,11 @@ class BaseBanditTest(object):
     def test_get_action_with_n_actions_none(self):
         policy = self.policy
         context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, action = policy.get_action(context, None)
+        history_id, recommendations = policy.get_action(context, None)
         self.assertEqual(history_id, 0)
-        self.assertIsInstance(action, dict)
-        self.assertIn(action['action'].id, self.action_storage.iterids())
+        self.assertIsInstance(recommendations, dict)
+        self.assertIn(recommendations['action'].id,
+                      self.action_storage.iterids())
         self.assertEqual(
             policy._history_storage.get_unrewarded_history(history_id).context,
             context)
@@ -50,11 +52,11 @@ class BaseBanditTest(object):
     def test_get_all_action(self):
         policy = self.policy
         context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, actions = policy.get_action(context, -1)
+        history_id, recommendations = policy.get_action(context, -1)
         self.assertEqual(history_id, 0)
-        self.assertEqual(len(actions), len(self.actions))
-        for action in actions:
-            self.assertIn(action['action'].id, self.action_storage.iterids())
+        self.assertEqual(len(recommendations), len(self.actions))
+        for rec in recommendations:
+            self.assertIn(rec['action'].id, self.action_storage.iterids())
         self.assertEqual(
             policy._history_storage.get_unrewarded_history(history_id).context,
             context)
@@ -63,11 +65,11 @@ class BaseBanditTest(object):
         policy = self.policy
         n_actions = 2
         context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}
-        history_id, actions = policy.get_action(context, n_actions)
+        history_id, recommendations = policy.get_action(context, n_actions)
         self.assertEqual(history_id, 0)
-        self.assertEqual(len(actions), n_actions)
-        for action in actions:
-            self.assertIn(action['action'].id, self.action_storage.iterids())
+        self.assertEqual(len(recommendations), n_actions)
+        for rec in recommendations:
+            self.assertIn(rec['action'].id, self.action_storage.iterids())
         self.assertEqual(
             policy._history_storage.get_unrewarded_history(history_id).context,
             context)

--- a/striatum/bandit/tests/test_exp3.py
+++ b/striatum/bandit/tests/test_exp3.py
@@ -27,23 +27,25 @@ class TestExp3(ChangeableActionSetBanditTest,
         policy.reward(history_id, {action[0]['action'].id: 1.0})
         model = policy._model_storage.get_model()
         self.assertEqual(len(model['w']), len(self.actions))
-        self.assertEqual(len(model['query_vector']), len(self.actions))
         self.assertGreater(model['w'][action[0]['action'].id], 1.)
 
     def test_add_action(self):
         policy = self.policy
-        history_id, _ = policy.get_action(context=None, n_actions=2)
+        history_id, recommendations = policy.get_action(context=None,
+                                                        n_actions=2)
         new_actions = [Action() for i in range(2)]
         policy.add_action(new_actions)
         self.assertEqual(len(new_actions) + len(self.actions),
                          policy._action_storage.count())
-        policy.reward(history_id, {3: 1})
+        policy.reward(history_id, {recommendations[0]['action'].id: 1.})
         model = policy._model_storage.get_model()
         for action in new_actions:
             self.assertEqual(model['w'][action.id], 1.0)
 
-        history_id2, actions = policy.get_action(context=None, n_actions=4)
-        self.assertEqual(len(actions), 4)
+        history_id2, recommendations2 = policy.get_action(context=None,
+                                                          n_actions=-1)
+        self.assertEqual(len(recommendations2),
+                         len(new_actions) + len(self.actions))
         policy.reward(history_id2, {new_actions[0].id: 4, new_actions[1].id: 5})
         model = policy._model_storage.get_model()
         for action in new_actions:

--- a/striatum/bandit/tests/test_exp3.py
+++ b/striatum/bandit/tests/test_exp3.py
@@ -23,11 +23,12 @@ class TestExp3(ChangeableActionSetBanditTest,
 
     def test_model_storage(self):
         policy = self.policy
-        history_id, action = policy.get_action(context=None, n_actions=1)
-        policy.reward(history_id, {action[0]['action'].id: 1.0})
+        history_id, recommendations = policy.get_action(context=None,
+                                                        n_actions=1)
+        policy.reward(history_id, {recommendations[0]['action'].id: 1.0})
         model = policy._model_storage.get_model()
         self.assertEqual(len(model['w']), len(self.actions))
-        self.assertGreater(model['w'][action[0]['action'].id], 1.)
+        self.assertGreater(model['w'][recommendations[0]['action'].id], 1.)
 
     def test_add_action(self):
         policy = self.policy

--- a/striatum/rewardplot.py
+++ b/striatum/rewardplot.py
@@ -24,7 +24,7 @@ def calculate_cum_reward(policy):
     cum_reward = {-1: 0.0}
     cum_n_actions = {-1: 0}
     for i in range(policy.history_storage.n_histories):
-        reward = policy.history_storage.get_history(i).reward
+        reward = policy.history_storage.get_history(i).rewards
         cum_n_actions[i] = cum_n_actions[i - 1] + len(reward)
         cum_reward[i] = cum_reward[i - 1] + sum(six.viewvalues(reward))
     return cum_reward, cum_n_actions


### PR DESCRIPTION
1. remove `query_vector` in the model and use the history instead (#108)
2. transform some `actions` to `recommendations`
3. reward only the recommended actions in test
4. fix `rewardplot.calculate_cum_reward`
