### PR TITLE
Test empty storage (resolved #114)

### DIFF
--- a/striatum/bandit/bandit.py
+++ b/striatum/bandit/bandit.py
@@ -69,6 +69,15 @@ class BaseBandit(object):
         """
         pass
 
+    def _get_action_with_empty_action_storage(self, context, n_actions):
+        if n_actions is None:
+            recommendations = None
+        else:
+            recommendations = []
+        history_id = self._history_storage.add_history(context,
+                                                       recommendations)
+        return history_id, recommendations
+
     @abstractmethod
     def reward(self, history_id, rewards):
         """Reward the previous action with reward.

--- a/striatum/bandit/exp3.py
+++ b/striatum/bandit/exp3.py
@@ -107,6 +107,10 @@ class Exp3(BaseBandit):
             Each dict contains
             {Action object, estimated_reward, uncertainty}.
         """
+        if self._action_storage.count() == 0:
+            return self._get_action_with_empty_action_storage(context,
+                                                              n_actions)
+
         probs = self._exp3_probs()
         if n_actions == -1:
             n_actions = self._action_storage.count()

--- a/striatum/bandit/linthompsamp.py
+++ b/striatum/bandit/linthompsamp.py
@@ -144,6 +144,10 @@ class LinThompSamp(BaseBandit):
             Each dict contains
             {Action object, estimated_reward, uncertainty}.
         """
+        if self._action_storage.count() == 0:
+            return self._get_action_with_empty_action_storage(context,
+                                                              n_actions)
+
         if not isinstance(context, dict):
             raise ValueError(
                 "LinThompSamp requires context dict for all actions!")

--- a/striatum/bandit/linucb.py
+++ b/striatum/bandit/linucb.py
@@ -123,6 +123,10 @@ class LinUCB(BaseBandit):
             Each dict contains
             {Action object, estimated_reward, uncertainty}.
         """
+        if self._action_storage.count() == 0:
+            return self._get_action_with_empty_action_storage(context,
+                                                              n_actions)
+
         if not isinstance(context, dict):
             raise ValueError("LinUCB requires context dict for all actions!")
         if n_actions == -1:

--- a/striatum/bandit/tests/base_bandit_test.py
+++ b/striatum/bandit/tests/base_bandit_test.py
@@ -139,6 +139,7 @@ class BaseBanditTest(object):
 
 
 class ChangeableActionSetBanditTest(object):
+    # pylint: disable=protected-access
 
     def test_add_action_change_storage(self):
         policy = self.policy
@@ -146,3 +147,10 @@ class ChangeableActionSetBanditTest(object):
         policy.add_action(new_actions)
         self.assertEqual(set(a.id for a in self.actions + new_actions),
                          set(self.action_storage.iterids()))
+
+    def test_add_action_from_empty_change_storage(self):
+        policy = self.policy_with_empty_action_storage
+        new_actions = [Action() for i in range(2)]
+        policy.add_action(new_actions)
+        self.assertEqual(set(a.id for a in new_actions),
+                         set(policy._action_storage.iterids()))

--- a/striatum/bandit/tests/base_bandit_test.py
+++ b/striatum/bandit/tests/base_bandit_test.py
@@ -26,6 +26,16 @@ class BaseBanditTest(object):
         self.assertEqual(self.history_storage, policy.history_storage)
         self.assertEqual(self.action_storage, policy._action_storage)
 
+    def test_get_action_with_empty_storage(self):
+        policy = self.policy_with_empty_action_storage
+        context = {}
+        history_id, recommendations = policy.get_action(context, 1)
+        self.assertEqual(history_id, 0)
+        self.assertEqual(len(recommendations), 0)
+        self.assertDictEqual(
+            policy._history_storage.get_unrewarded_history(history_id).context,
+            context)
+
     def test_get_first_action(self):
         policy = self.policy
         context = {1: [1, 1], 2: [2, 2], 3: [3, 3]}

--- a/striatum/bandit/tests/test_exp3.py
+++ b/striatum/bandit/tests/test_exp3.py
@@ -1,7 +1,12 @@
 import unittest
 
 from striatum.bandit import Exp3
-from striatum.storage import Action
+from striatum.storage import (
+    MemoryHistoryStorage,
+    MemoryModelStorage,
+    MemoryActionStorage,
+    Action,
+)
 from .base_bandit_test import BaseBanditTest, ChangeableActionSetBanditTest
 
 
@@ -15,6 +20,9 @@ class TestExp3(ChangeableActionSetBanditTest,
         self.gamma = 0.5
         self.policy = Exp3(self.history_storage, self.model_storage,
                            self.action_storage, gamma=self.gamma)
+        self.policy_with_empty_action_storage = Exp3(
+            MemoryHistoryStorage(), MemoryModelStorage(), MemoryActionStorage(),
+            gamma=self.gamma)
 
     def test_initialization(self):
         super(TestExp3, self).test_initialization()

--- a/striatum/bandit/tests/test_linthompsamp.py
+++ b/striatum/bandit/tests/test_linthompsamp.py
@@ -1,7 +1,12 @@
 import unittest
 
 from striatum.bandit import LinThompSamp
-from striatum.storage import Action
+from striatum.storage import (
+    MemoryHistoryStorage,
+    MemoryModelStorage,
+    MemoryActionStorage,
+    Action,
+)
 from .base_bandit_test import BaseBanditTest, ChangeableActionSetBanditTest
 
 
@@ -19,6 +24,10 @@ class TestLinThompSamp(ChangeableActionSetBanditTest,
         self.policy = LinThompSamp(
             self.history_storage, self.model_storage,
             self.action_storage, context_dimension=self.context_dimension,
+            delta=self.delta, R=self.R, epsilon=self.epsilon)
+        self.policy_with_empty_action_storage = LinThompSamp(
+            MemoryHistoryStorage(), MemoryModelStorage(), MemoryActionStorage(),
+            context_dimension=self.context_dimension,
             delta=self.delta, R=self.R, epsilon=self.epsilon)
 
     def test_initialization(self):

--- a/striatum/bandit/tests/test_linucb.py
+++ b/striatum/bandit/tests/test_linucb.py
@@ -5,7 +5,12 @@ import unittest
 import numpy as np
 
 from striatum.bandit import LinUCB
-from striatum.storage import Action
+from striatum.storage import (
+    MemoryHistoryStorage,
+    MemoryModelStorage,
+    MemoryActionStorage,
+    Action,
+)
 from .base_bandit_test import BaseBanditTest, ChangeableActionSetBanditTest
 
 
@@ -22,6 +27,9 @@ class TestLinUCB(ChangeableActionSetBanditTest,
             self.history_storage, self.model_storage,
             self.action_storage, context_dimension=self.context_dimension,
             alpha=self.alpha)
+        self.policy_with_empty_action_storage = LinUCB(
+            MemoryHistoryStorage(), MemoryModelStorage(), MemoryActionStorage(),
+            context_dimension=self.context_dimension, alpha=self.alpha)
 
     def test_initialization(self):
         super(TestLinUCB, self).test_initialization()

--- a/striatum/bandit/tests/test_ucb1.py
+++ b/striatum/bandit/tests/test_ucb1.py
@@ -1,7 +1,12 @@
 import unittest
 
 from striatum.bandit import UCB1
-from striatum.storage import Action
+from striatum.storage import (
+    MemoryHistoryStorage,
+    MemoryModelStorage,
+    MemoryActionStorage,
+    Action,
+)
 from .base_bandit_test import BaseBanditTest, ChangeableActionSetBanditTest
 
 
@@ -14,6 +19,8 @@ class TestUCB1(ChangeableActionSetBanditTest,
         super(TestUCB1, self).setUp()
         self.policy = UCB1(
             self.history_storage, self.model_storage, self.action_storage)
+        self.policy_with_empty_action_storage = UCB1(
+            MemoryHistoryStorage(), MemoryModelStorage(), MemoryActionStorage())
 
     def test_model_storage(self):
         policy = self.policy

--- a/striatum/bandit/ucb1.py
+++ b/striatum/bandit/ucb1.py
@@ -89,6 +89,10 @@ class UCB1(BaseBandit):
             Each dict contains
             {Action object, estimated_reward, uncertainty}.
         """
+        if self._action_storage.count() == 0:
+            return self._get_action_with_empty_action_storage(context,
+                                                              n_actions)
+
         estimated_reward, uncertainty, score = self._ucb1_score()
         if n_actions == -1:
             n_actions = self._action_storage.count()


### PR DESCRIPTION
resolved #114
handle the boundary case: policy init with empty action storage 
When `get_action()`, if `n_actions` is `None`, then the `recommendations` will be `None`.
If `n_actions` is an `int`, then the `recommendations` will be `[]`.